### PR TITLE
fix: auto advance node not working well

### DIFF
--- a/frontend/store/experiments.ts
+++ b/frontend/store/experiments.ts
@@ -291,15 +291,21 @@ export const createExperimentsSlice: StateCreator<
           // Poll the tree graph to find the newly created child.
           console.warn('[advanceSimulation] advance_chain failed, polling graph for new child...', advanceError?.message || advanceError);
           let found: number | null = null;
-          for (let attempt = 0; attempt < 60; attempt++) {
+          // Phase 1: find the new child. Phase 2: wait for its simulation to finish.
+          // Both handled in one loop — breaks only when child is found AND no longer running.
+          // 1800 attempts × 2 s = up to 1 hour, covering very long LLM runs.
+          for (let attempt = 0; attempt < 1800; attempt++) {
             await new Promise((r) => setTimeout(r, 2000));
             const polledGraph = await getTreeGraph(base, simId, token);
             if (!polledGraph) continue;
-            const newChild = polledGraph.edges.find(
-              (e: any) => e.from === parentNumeric && !existingChildIds.has(e.to)
-            );
-            if (newChild) {
-              found = newChild.to;
+            if (found == null) {
+              const newChild = polledGraph.edges.find(
+                (e: any) => e.from === parentNumeric && !existingChildIds.has(e.to)
+              );
+              if (newChild) found = newChild.to;
+            }
+            // Break only when found AND simulation complete (not in running set)
+            if (found != null && !(polledGraph.running || []).includes(found)) {
               break;
             }
           }
@@ -307,7 +313,7 @@ export const createExperimentsSlice: StateCreator<
             throw advanceError;
           }
           res = { child: found };
-          console.log('[advanceSimulation] Recovered from 504 — found child node', found);
+          console.log('[advanceSimulation] Recovered from 504 — found and awaited child node', found);
         }
 
         // Refresh tree graph


### PR DESCRIPTION
After a proxy 504, the recovery loop previously broke as soon as the child node was found in the tree graph (which happens immediately at attach, before LLM calls run). This caused advanceSimulation() to return while the simulation was still in flight, letting startAutoAdvance kick off the next step immediately — stacking concurrent LLM calls on the same GPU and ensuring getSimEvents() always returned empty logs.

The loop now also waits for the child to leave graph.running (set by the backend once simulator.run() finishes) before breaking. This keeps the behaviour identical to the non-504 path: each advance only returns after the simulation is truly complete, preventing concurrency and ensuring getSimEvents() sees the full event log.

The 1800-attempt × 2 s ceiling (1 hour) covers very long LLM runs. This also fixes the export-vs-UI node-count discrepancy: session.commit() fires just after record.running.remove(), so by the time the next advance starts the previous node is persisted to the database.

https://claude.ai/code/session_01XX6K5LCxbMhE6jyEnTph2N