### PR TITLE
update llm setting ui

### DIFF
--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from "react";
 import { Menu, MoonStar, SunMedium, X } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { BrandLogo } from "./BrandLogo";
 import { LanguageSwitcher } from "./LanguageSwitcher";
-import { useSimulationStore } from "../store";
 import { useAuthStore } from "../store/auth";
 import { useThemeStore } from "../store/theme";
 
@@ -20,24 +18,21 @@ export function NavBar({ variant = "default" }: { variant?: NavBarVariant }) {
   const user = useAuthStore((s) => s.user);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const clearSession = useAuthStore((s) => s.clearSession);
-  const currentSimulationId = useSimulationStore((s) => s.currentSimulation?.id ?? null);
 
   const mode = useThemeStore((s) => s.mode);
   const toggle = useThemeStore((s) => s.toggle);
 
   const isProduct = variant === "product";
   const isAdmin = String(user?.role ?? "") === "admin";
-  const workspaceLink = currentSimulationId ? `/simulations/${currentSimulationId}` : "/simulations/workspace";
   const navItems = [
-    { id: "dashboard", to: "/dashboard", label: t("nav.dashboard") },
-    { id: "new", to: "/simulations/new", label: t("nav.new") },
-    { id: "workspace", to: workspaceLink, label: t("nav.workspace", { defaultValue: "实验台" }) },
-    { id: "saved", to: "/simulations/saved", label: t("nav.saved") },
-    { id: "settings", to: "/settings", label: t("nav.settings") },
-    { id: "docs", to: "/docs", label: t("nav.docs") || "Docs" },
+    { to: "/dashboard", label: t("nav.dashboard") },
+    { to: "/simulations/new", label: t("nav.new") },
+    { to: "/simulations/saved", label: t("nav.saved") },
+    { to: "/settings/providers", label: t("nav.settings") },
+    { to: "/docs", label: t("nav.docs") || "Docs" },
   ];
   const allNavItems = isAdmin
-    ? [...navItems, { id: "admin", to: "/admin", label: t("nav.admin") || "Admin" }]
+    ? [...navItems, { to: "/admin", label: t("nav.admin") || "Admin" }]
     : navItems;
   const themeIcon =
     isProduct
@@ -70,46 +65,13 @@ export function NavBar({ variant = "default" }: { variant?: NavBarVariant }) {
     return () => media.removeEventListener("change", closeCompact);
   }, [isProduct]);
 
-  const isNavItemActive = (itemId: string, itemTo: string) => {
-    if (itemId === "dashboard") {
-      return location.pathname.startsWith("/dashboard");
-    }
-
-    if (itemId === "new") {
-      return location.pathname.startsWith("/simulations/new");
-    }
-
-    if (itemId === "workspace") {
-      return (
-        location.pathname === "/simulations/workspace" ||
-        (location.pathname.startsWith("/simulations/") &&
-          !location.pathname.startsWith("/simulations/new") &&
-          !location.pathname.startsWith("/simulations/saved"))
-      );
-    }
-
-    if (itemId === "saved") {
-      return location.pathname.startsWith("/simulations/saved");
-    }
-
-    if (itemId === "settings") {
-      return location.pathname.startsWith("/settings");
-    }
-
-    if (itemId === "docs") {
-      return location.pathname.startsWith("/docs");
-    }
-
-    return location.pathname.startsWith(itemTo);
-  };
-
   const renderNavLinks = (extraClass = "") =>
     allNavItems.map((item) => (
       <Link
-        key={item.id}
+        key={item.to}
         to={item.to}
         className={`nav-link ${extraClass} ${
-          isNavItemActive(item.id, item.to) ? "active" : ""
+          location.pathname.startsWith(item.to) ? "active" : ""
         }`.trim()}
       >
         {item.label}
@@ -121,7 +83,7 @@ export function NavBar({ variant = "default" }: { variant?: NavBarVariant }) {
       <div className="nav-shell">
         <div className="nav-left">
           <Link to="/" className="nav-brand">
-            <BrandLogo />
+            {t("brand")}
           </Link>
 
           <div className="nav-links nav-links--desktop">

--- a/frontend/components/layout/AuthLayout.tsx
+++ b/frontend/components/layout/AuthLayout.tsx
@@ -1,8 +1,9 @@
-import { Atom, MoonStar, SunMedium } from "lucide-react";
+import { ArrowRight, MoonStar, SunMedium } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { LanguageSwitcher } from "../LanguageSwitcher";
+import { BrandLogo } from "../BrandLogo";
 import { useThemeStore } from "../../store/theme";
 
 export function AuthLayout({ children }: { children: React.ReactNode }) {
@@ -19,17 +20,25 @@ export function AuthLayout({ children }: { children: React.ReactNode }) {
       : isZh
         ? "切换到夜间模式"
         : "Switch to dark mode";
+  const heroTags = [
+    t("landing.hero.tag1"),
+    t("landing.hero.tag2"),
+    t("landing.hero.tag3"),
+  ];
 
   return (
     <div className={`ss-auth ${themeClass}`.trim()}>
       <div className="ss-auth-shell">
         <header className="ss-auth__topbar">
           <Link to="/" className="ss-auth__topbar-brand">
-            <div className="ss-auth__brand-mark">
-              <Atom size={18} />
-            </div>
-            <span className="ss-auth__brand-link">FOS</span>
+            <BrandLogo layout="stacked" />
           </Link>
+
+          <nav className="ss-auth__topbar-nav" aria-label={isZh ? "主导航" : "Primary"}>
+            <Link to="/simulations/new">{isZh ? "EXHIBITS" : "EXHIBITS"}</Link>
+            <Link to="/simulations/saved">{isZh ? "JOURNALS" : "JOURNALS"}</Link>
+            <Link to="/docs">{isZh ? "INDEX" : "INDEX"}</Link>
+          </nav>
 
           <div className="ss-auth__topbar-controls">
             <button
@@ -48,48 +57,35 @@ export function AuthLayout({ children }: { children: React.ReactNode }) {
         <section className="ss-auth__hero">
           <div className="ss-auth__hero-grid" />
           <div className="ss-auth__hero-content">
-            <div className="ss-auth__hero-body">
-              <div className="ss-auth__hero-badge">
-                <span className="ss-auth__hero-badge-dot" />
-                {t("auth.layout.badge")}
-              </div>
-
-              <div className="space-y-5">
-                <h1 className="ss-auth__hero-title">
-                  <span className="ss-auth__hero-title-line">{t("auth.layout.line1")}</span>
-                  <span className="ss-auth__hero-title-line">{t("auth.layout.line2")}</span>
-                  <span className="ss-auth__hero-title-accent">{t("auth.layout.accent")}</span>
-                </h1>
-                <p className="ss-auth__hero-copy">{t("auth.layout.copy")}</p>
-              </div>
-            </div>
-
-            <div className="ss-auth__hero-tags">
-              <span className="ss-auth__hero-tag">{t("auth.layout.tag1")}</span>
-              <span className="ss-auth__hero-tag">{t("auth.layout.tag2")}</span>
-              <span className="ss-auth__hero-tag">{t("auth.layout.tag3")}</span>
-            </div>
-
-            <div className="ss-auth__hero-surface">
-              <div className="ss-auth__hero-surface-kicker">{t("auth.layout.surfaceLabel")}</div>
-              <div className="ss-auth__hero-surface-grid">
-                <div className="ss-auth__hero-surface-item">
-                  <div className="ss-auth__hero-surface-title">{t("auth.layout.surface1Title")}</div>
-                  <p className="ss-auth__hero-surface-copy">{t("auth.layout.surface1Body")}</p>
+            <div className="ss-auth__hero-frame">
+              <div className="ss-auth__hero-surface">
+                <div className="ss-auth__hero-badge">
+                  <span className="ss-auth__hero-badge-dot" />
+                  {t("landing.hero.badge")}
                 </div>
-                <div className="ss-auth__hero-surface-item">
-                  <div className="ss-auth__hero-surface-title">{t("auth.layout.surface2Title")}</div>
-                  <p className="ss-auth__hero-surface-copy">{t("auth.layout.surface2Body")}</p>
+
+                <div className="ss-auth__hero-main">
+                  <h1 className="ss-auth__hero-display">{t("landing.hero.line1")}</h1>
+                  <p className="ss-auth__hero-accent">{t("landing.hero.accent")}</p>
+                  <p className="ss-auth__hero-copy">{t("landing.hero.sub")}</p>
                 </div>
-                <div className="ss-auth__hero-surface-item">
-                  <div className="ss-auth__hero-surface-title">{t("auth.layout.surface3Title")}</div>
-                  <p className="ss-auth__hero-surface-copy">{t("auth.layout.surface3Body")}</p>
+
+                <div className="ss-auth__hero-actions">
+                  <Link to="/simulations/new" className="ss-auth__hero-action ss-auth__hero-action--primary">
+                    <span>{t("landing.hero.primaryCta")}</span>
+                    <ArrowRight size={16} />
+                  </Link>
+                  <Link to="/docs" className="ss-auth__hero-action ss-auth__hero-action--ghost">
+                    {t("landing.hero.secondaryCta")}
+                  </Link>
+                </div>
+
+                <div className="ss-auth__hero-tags">
+                  {heroTags.map((tag) => (
+                    <span key={tag} className="ss-auth__hero-tag">{tag}</span>
+                  ))}
                 </div>
               </div>
-            </div>
-
-            <div className="ss-auth__hero-note">
-              {t("auth.layout.note")}
             </div>
           </div>
         </section>

--- a/frontend/locales/zh.json
+++ b/frontend/locales/zh.json
@@ -27,11 +27,11 @@
   },
   "landing": {
     "hero": {
-      "badge": "社会系统实验室 Social Systems Laboratory",
-      "line1": "以精密模拟架构",
-      "line2": "社会逻辑",
-      "accent": "构建社会逻辑",
-      "sub": "为研究者、政策制定者与社会科学家打造的跨领域模拟平台。通过分支、观测与干预，洞察复杂系统的深层演化规律。",
+      "badge": "社会系统模拟平台\nFOS",
+      "line1": "Future of Society",
+      "line2": "",
+      "accent": "",
+      "sub": "面向研究、推演与决策验证的社会系统模拟平台，\n通过分支、观测与干预理解复杂系统如何演化。",
       "primaryCta": "进入实验室",
       "secondaryCta": "阅读方法论",
       "tag1": "高保真模拟",

--- a/frontend/pages/LandingPage.tsx
+++ b/frontend/pages/LandingPage.tsx
@@ -17,7 +17,6 @@ import { useTranslation } from "react-i18next";
 import { useThemeStore } from "../store/theme";
 
 import landingDemoVideo from "../assets/landing/landing-demo.mp4";
-import heroPreviewBackground from "../assets/landing/preview-hero-bg.png";
 import sceneBehaviorImage from "../assets/landing/scene-behavior.png";
 import sceneInstitutionImage from "../assets/landing/scene-institution.png";
 import sceneInterventionImage from "../assets/landing/scene-intervention.png";
@@ -30,9 +29,18 @@ export function LandingPage() {
   const { t } = useTranslation();
   const mode = useThemeStore((state) => state.mode);
   const themeClass = mode === "dark" ? "is-dark" : "is-light";
-  const landingMediaVars = {
-    "--ss-landing-hero-image": `url(${heroPreviewBackground})`,
-  } as React.CSSProperties;
+  const heroSubtitle = String(t("landing.hero.sub"));
+  const heroSubtitleLines = heroSubtitle
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const heroSubtitleSegments =
+    heroSubtitleLines.length > 1
+      ? heroSubtitleLines
+      : heroSubtitle
+          .split(/(?<=[,，。.!?；;])/u)
+          .map((segment) => segment.trim())
+          .filter(Boolean);
 
   useEffect(() => {
     const sections = document.querySelectorAll<HTMLElement>(".ss-reveal");
@@ -142,22 +150,32 @@ export function LandingPage() {
   ];
 
   return (
-    <div className={`ss-landing ${themeClass}`.trim()} style={landingMediaVars}>
+    <div className={`ss-landing ${themeClass}`.trim()}>
       <section className="ss-landing__hero ss-reveal">
         <div className="ss-landing__frame ss-landing__hero-grid">
           <div className="ss-landing__hero-copy">
             <div className="ss-landing__hero-stage">
               <div className="ss-landing__hero-body">
-                <div className="ss-landing__eyebrow ss-landing__eyebrow--hero">{t("landing.hero.badge")}</div>
-
                 <div className="ss-landing__headline-group">
-                  <h1 className="ss-landing__title">
-                    <span className="ss-landing__title-line">{t("landing.hero.line1")}</span>
-                    <span className="ss-landing__title-line">{t("landing.hero.line2")}</span>
-                    <span className="ss-landing__title-accent">{t("landing.hero.accent")}</span>
-                  </h1>
+                  <div className="ss-landing__title-stack">
+                    <h1 className="ss-landing__title">
+                      <span className="ss-landing__title-line">{t("landing.hero.line1")}</span>
+                      <span className="ss-landing__title-line">{t("landing.hero.line2")}</span>
+                      <span className="ss-landing__title-accent">{t("landing.hero.accent")}</span>
+                    </h1>
 
-                  <p className="ss-landing__subtitle">{t("landing.hero.sub")}</p>
+                    <div className="ss-landing__eyebrow ss-landing__eyebrow--hero">
+                      {t("landing.hero.badge")}
+                    </div>
+                  </div>
+
+                  <p className="ss-landing__subtitle ss-landing__subtitle--dynamic">
+                    {heroSubtitleSegments.map((segment) => (
+                      <span key={segment} className="ss-landing__subtitle-segment">
+                        {segment}
+                      </span>
+                    ))}
+                  </p>
                 </div>
               </div>
 
@@ -264,39 +282,7 @@ export function LandingPage() {
               >
                 {t("landing.preview.title")}
               </video>
-
-              <div className="ss-landing__preview-float">
-                <span>{t("landing.preview.overlayLabel")}</span>
-                <span>{t("landing.preview.overlayBranch")}</span>
-              </div>
             </div>
-
-            <aside className="ss-landing__preview-rail">
-              <div className="ss-landing__preview-panel">
-                <div className="ss-landing__preview-overlay-head">
-                  <span>{t("landing.preview.overlayLabel")}</span>
-                  <span>{t("landing.preview.overlayBranch")}</span>
-                </div>
-                <div className="ss-landing__preview-meter">
-                  <div className="ss-landing__preview-meter-fill" />
-                </div>
-                <p className="ss-landing__preview-overlay-copy">{t("landing.preview.overlayBody")}</p>
-              </div>
-
-              <div className="ss-landing__preview-signal-list">
-                {heroTags.map((tag) => (
-                  <div key={tag} className="ss-landing__preview-signal">
-                    <span className="ss-landing__preview-signal-dot" />
-                    <span>{tag}</span>
-                  </div>
-                ))}
-              </div>
-
-              <Link to="/simulations/new" className="ss-landing__preview-link ss-landing__preview-link--panel">
-                <span>{t("landing.hero.primaryCta")}</span>
-                <ArrowRight className="ss-landing__preview-link-icon" size={16} />
-              </Link>
-            </aside>
           </div>
         </div>
       </section>

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ArrowRight, AtSign, KeyRound, LifeBuoy, LockKeyhole, ShieldCheck } from "lucide-react";
+import { ArrowRight, AtSign, LockKeyhole } from "lucide-react";
 
 import { apiClient } from "../services/client";
 import { useAuthStore } from "../store/auth";
@@ -51,9 +51,13 @@ export function LoginPage() {
   };
 
   return (
-    <section className="ss-auth__card">
-      <div className="space-y-3">
-        <div className="ss-auth__hero-badge">{t("auth.login.badge")}</div>
+    <section className="ss-auth__card ss-auth__login-card">
+      <div className="ss-auth__login-intro">
+        <div className="ss-auth__hero-badge">
+          <span className="ss-auth__hero-badge-dot" />
+          {t("auth.login.badge")}
+        </div>
+
         <div className="space-y-2">
           <h2 className="ss-auth__title">
             {t("auth.login.welcome")}
@@ -64,7 +68,7 @@ export function LoginPage() {
         </div>
       </div>
 
-      <form onSubmit={onSubmit} className="mt-8 space-y-5">
+      <form onSubmit={onSubmit} className="ss-auth__login-form">
         <div>
           <label htmlFor="login-email" className="ss-auth__label">
             {t("auth.login.email")}
@@ -75,6 +79,7 @@ export function LoginPage() {
               id="login-email"
               className="ss-input ss-auth__input"
               type="email"
+              autoComplete="email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
               placeholder={t("auth.login.emailPlaceholder")}
@@ -93,6 +98,7 @@ export function LoginPage() {
               id="login-password"
               className="ss-input ss-auth__input"
               type="password"
+              autoComplete="current-password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
               placeholder={t("auth.login.passwordPlaceholder")}
@@ -113,32 +119,6 @@ export function LoginPage() {
         </button>
       </form>
 
-      <div className="ss-auth__trust-row">
-        <div className="ss-auth__trust-item">
-          <ShieldCheck size={15} />
-          <span>{t("auth.login.credentialCheck")}</span>
-        </div>
-        <div className="ss-auth__trust-item">
-          <KeyRound size={15} />
-          <span>{t("auth.login.workspaceBound")}</span>
-        </div>
-      </div>
-
-      <div className="ss-auth__action-list">
-        <button type="button" className="ss-auth__support-link">
-          <KeyRound size={15} />
-          <span>{t("auth.login.forgot")}</span>
-        </button>
-        <button type="button" className="ss-auth__support-link">
-          <ShieldCheck size={15} />
-          <span>{t("auth.login.sso")}</span>
-        </button>
-        <button type="button" className="ss-auth__support-link">
-          <LifeBuoy size={15} />
-          <span>{t("auth.login.help")}</span>
-        </button>
-      </div>
-
       <div className="ss-auth__footer">
         <p className="ss-auth__footer-text">
           {t("auth.login.noAccount")}{" "}
@@ -146,10 +126,6 @@ export function LoginPage() {
             {t("auth.login.create")}
           </Link>
         </p>
-        <div className="ss-auth__footer-note">
-          <span>{t("auth.login.footerLeft")}</span>
-          <span>{t("auth.login.footerRight")}</span>
-        </div>
       </div>
     </section>
   );

--- a/frontend/pages/SettingsPage.tsx
+++ b/frontend/pages/SettingsPage.tsx
@@ -1,18 +1,34 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
-import { createProvider as apiCreateProvider, listProviders, testProvider as apiTestProvider, updateProvider, deleteProvider as apiDeleteProvider, activateProvider as apiActivateProvider, type Provider } from "../services/providers";
-import { listSearchProviders, createSearchProvider, updateSearchProvider, type SearchProvider } from "../services/searchProviders";
-import { listUploads, deleteUpload, findOrphans, type UploadedFile } from "../services/uploads";
-import { useAuthStore } from "../store/auth";
+import {
+  Bot,
+  Database,
+  FileStack,
+  LogOut,
+  Search,
+  Shield,
+  UserCircle2,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { TitleCard } from "../components/TitleCard";
+import {
+  FilePlusIcon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
+
 import { AppSelect } from "../components/AppSelect";
-import { Link2Icon, TrashIcon, FilePlusIcon, StarIcon, StarFilledIcon, EyeOpenIcon, EyeClosedIcon } from "@radix-ui/react-icons";
+import { TitleCard } from "../components/TitleCard";
+import { ProviderManagementPage } from "../components/provider-management/ProviderManagementPage";
+import {
+  createSearchProvider,
+  listSearchProviders,
+  updateSearchProvider,
+} from "../services/searchProviders";
+import { deleteUpload, findOrphans, listUploads } from "../services/uploads";
+import { useAuthStore } from "../store/auth";
 
 type Tab = "profile" | "security" | "providers_llm" | "providers_search" | "files";
 
-// Helper to get capability rows with translations
 const getCapabilityRows = (t: (key: string) => string) => [
   {
     model: "gpt-4o-mini",
@@ -48,34 +64,51 @@ const getCapabilityRows = (t: (key: string) => string) => [
   },
 ];
 
-// Provider type comes from ../api/providers
+function SettingsMetric({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="ss-settings-metric ss-inset">
+      <div className="ss-settings-metric__icon">{icon}</div>
+      <div>
+        <div className="ss-settings-metric__label">{label}</div>
+        <strong className="ss-settings-metric__value">{value}</strong>
+      </div>
+    </div>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="ss-settings-info-row">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
 
 export function SettingsPage() {
-  const { t } = useTranslation();
-
-  // Format file size helper
-  const formatSize = (bytes: number): string => {
-    if (bytes < 1024) return `${bytes}${t('settings.files.byte')}`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}${t('settings.files.kb')}`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)}${t('settings.files.mb')}`;
-  };
-
-  // Format date helper
-  const formatDate = (timestamp: number): string => {
-    return new Date(timestamp * 1000).toLocaleString();
-  };
-  const [activeTab, setActiveTab] = useState<Tab>("profile");
+  const { t, i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
+  const location = useLocation();
+  const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
   const clearSession = useAuthStore((state) => state.clearSession);
   const queryClient = useQueryClient();
-  const [testHints, setTestHints] = useState<Record<number, { ok: boolean; msg: string }>>({});
-  const [testingId, setTestingId] = useState<number | null>(null);
-
-
-  const providersQuery = useQuery({
-    queryKey: ["providers"],
-    enabled: activeTab === "providers_llm",
-    queryFn: () => listProviders(),
+  const [activeTab, setActiveTab] = useState<Tab>("profile");
+  const [orphanResult, setOrphanResult] = useState<{ orphaned: string[]; total: number } | null>(null);
+  const [findingOrphans, setFindingOrphans] = useState(false);
+  const [searchDraft, setSearchDraft] = useState({
+    provider: "ddg",
+    base_url: "",
+    api_key: "",
+    config: { region: "", safesearch: "moderate" } as Record<string, any>,
   });
 
   const searchProvidersQuery = useQuery({
@@ -97,58 +130,9 @@ export function SettingsPage() {
     },
   });
 
-  const [orphanResult, setOrphanResult] = useState<{ orphaned: string[]; total: number } | null>(null);
-  const [findingOrphans, setFindingOrphans] = useState(false);
-
-  const searchProvider = useMemo(() => {
-    const items = searchProvidersQuery.data || [];
-    return items[0] || null;
-  }, [searchProvidersQuery.data]);
-
-  const [providerDraft, setProviderDraft] = useState({
-    name: "",
-    provider: "openai",
-    model: "gpt-4",
-    base_url: "https://api.openai.com/v1",
-    api_key: "",
-  });
-  const [keyVisible, setKeyVisible] = useState(false);
-
-  const [searchDraft, setSearchDraft] = useState({
-    provider: "ddg",
-    base_url: "",
-    api_key: "",
-    config: { region: "", safesearch: "moderate" } as Record<string, any>,
-  });
-
-  useEffect(() => {
-    if (!searchProvider) return;
-    setSearchDraft({
-      provider: searchProvider.provider || "ddg",
-      base_url: String(searchProvider.base_url || ""),
-      api_key: "",
-      config: (searchProvider as any).config || {},
-    });
-  }, [searchProvider]);
-
-  const createProvider = useMutation({
-    mutationFn: async () =>
-      apiCreateProvider({
-        name: providerDraft.name,
-        provider: providerDraft.provider,
-        model: providerDraft.model,
-        base_url: providerDraft.base_url,
-        api_key: providerDraft.api_key,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-      setProviderDraft({ name: "", provider: "openai", model: "gpt-4", base_url: "https://api.openai.com/v1", api_key: "" });
-      setKeyVisible(false);
-    },
-  });
-
   const upsertSearch = useMutation({
     mutationFn: async () => {
+      const searchProvider = (searchProvidersQuery.data ?? [])[0];
       if (searchProvider) {
         return updateSearchProvider(searchProvider.id, {
           provider: searchDraft.provider,
@@ -169,542 +153,459 @@ export function SettingsPage() {
     },
   });
 
-  const testProvider = useMutation({
-    mutationFn: async (providerId: number) => apiTestProvider(providerId),
-    onMutate: (providerId: number) => {
-      setTestingId(providerId);
-    },
-    onSuccess: (_data, providerId) => {
-      setTestHints((prev) => ({ ...prev, [providerId]: { ok: true, msg: t('settings.providers.testOk') || 'OK' } }));
-      setTimeout(() => {
-        setTestHints((prev) => {
-          const copy = { ...prev } as Record<number, { ok: boolean; msg: string }>;
-          delete copy[providerId];
-          return copy;
-        });
-      }, 3000);
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-    },
-    onError: (_err, providerId) => {
-      setTestHints((prev) => ({ ...prev, [providerId]: { ok: false, msg: t('settings.providers.testFail') || 'Failed' } }));
-      setTimeout(() => {
-        setTestHints((prev) => {
-          const copy = { ...prev } as Record<number, { ok: boolean; msg: string }>;
-          delete copy[providerId];
-          return copy;
-        });
-      }, 3000);
-    },
-    onSettled: () => {
-      setTestingId(null);
-    },
-  });
+  const searchProviders = searchProvidersQuery.data ?? [];
+  const uploads = filesQuery.data ?? [];
+  const searchProvider = searchProviders[0] || null;
 
-  const activateProvider = useMutation({
-    mutationFn: async (providerId: number) => apiActivateProvider(providerId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-    },
-  });
+  useEffect(() => {
+    if (!searchProvider) return;
+    setSearchDraft({
+      provider: searchProvider.provider || "ddg",
+      base_url: String(searchProvider.base_url || ""),
+      api_key: "",
+      config: (searchProvider as any).config || {},
+    });
+  }, [searchProvider]);
 
-  const deleteProvider = useMutation({
-    mutationFn: async (providerId: number) => apiDeleteProvider(providerId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-    },
-  });
-
-  const handleCreateProvider = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    createProvider.mutate();
+  const formatSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes}${t("settings.files.byte")}`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}${t("settings.files.kb")}`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}${t("settings.files.mb")}`;
   };
 
-  const tabContent = useMemo(() => {
-    if (activeTab === "profile") {
-      return (
-        <div className="panel" style={{ gap: "var(--ss-space-2)" }}>
-          <div className="panel-title">{t('settings.tabs.profile')}</div>
-          <div className="card">
-            <div><strong>{t('settings.profile.email')}:</strong> {String(user?.email ?? "")}</div>
-            <div><strong>{t('settings.profile.username')}:</strong> {String(user?.username ?? "")}</div>
-            <div><strong>{t('settings.profile.fullName')}:</strong> {String(user?.full_name ?? "")}</div>
-            <div><strong>{t('settings.profile.organization')}:</strong> {String(user?.organization ?? "")}</div>
-          </div>
-        </div>
-      );
-    }
+  const formatDate = (timestamp: number): string => new Date(timestamp * 1000).toLocaleString();
 
-    if (activeTab === "security") {
-      return (
-        <div className="panel" style={{ gap: "var(--ss-space-2)" }}>
-          <div className="panel-title">{t('settings.tabs.security')}</div>
-          <div className="card">
-            <p>{t('settings.security.placeholder')}</p>
-            <button type="button" className="button button-danger" style={{ alignSelf: "flex-start" }} onClick={() => clearSession()}>
-              {t('settings.security.signoutAll')}
-            </button>
-          </div>
-        </div>
-      );
-    }
+  const tabItems = [
+    {
+      id: "profile" as const,
+      title: t("settings.tabs.profile"),
+      hint: isZh ? "身份与工作空间归属" : "Identity and workspace ownership",
+      icon: <UserCircle2 size={15} />,
+    },
+    {
+      id: "security" as const,
+      title: t("settings.tabs.security"),
+      hint: isZh ? "会话访问与退出控制" : "Session access and sign-out controls",
+      icon: <Shield size={15} />,
+    },
+    {
+      id: "providers_llm" as const,
+      title: "LLM 配置",
+      hint: isZh ? "模型与接口配置" : "Model and interface configuration",
+      icon: <Bot size={15} />,
+    },
+    {
+      id: "providers_search" as const,
+      title: t("settings.tabs.searchProviders") || t("settings.providers.searchTab"),
+      hint: isZh ? "搜索与检索提供商" : "Search and retrieval providers",
+      icon: <Search size={15} />,
+    },
+    {
+      id: "files" as const,
+      title: t("settings.tabs.files"),
+      hint: isZh ? "文件上传与存储整理" : "Uploads and storage hygiene",
+      icon: <FileStack size={15} />,
+    },
+  ];
 
-    return (
-      <div className="panel" style={{ gap: "var(--ss-space-3)" }}>
-        <div className="panel-header" style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
-          <div className="panel-title">{t('settings.providers.title')}</div>
-          {activeTab === 'providers_llm' && (
-            (() => {
-              const activeProv = (providersQuery.data || []).find((p) => p.is_active);
-              const name = activeProv ? activeProv.name : '-';
-              return (
-                <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-md)' }}>
-                  {t('settings.providers.current', { name })}
-                </div>
-              );
-            })()
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const nextTab = params.get("tab");
+    if (
+      nextTab === "profile" ||
+      nextTab === "security" ||
+      nextTab === "providers_llm" ||
+      nextTab === "providers_search" ||
+      nextTab === "files"
+    ) {
+      setActiveTab(nextTab);
+    }
+  }, [location.search]);
+
+  const selectTab = (tab: Tab) => {
+    setActiveTab(tab);
+    const params = new URLSearchParams(location.search);
+    params.set("tab", tab);
+    navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
+  };
+
+  const renderProfile = () => (
+    <div className="ss-settings-section">
+      <section className="ss-settings-hero ss-surface-strong">
+        <div>
+          <div className="kicker">{t("settings.tabs.profile")}</div>
+          <h2 className="section-title">{String(user?.full_name ?? user?.username ?? t("brand"))}</h2>
+          <p className="panel-subtitle">{t("settings.subtitle")}</p>
+        </div>
+        <div className="ss-settings-info-grid">
+          <InfoRow label={t("settings.profile.email")} value={String(user?.email ?? "—")} />
+          <InfoRow label={t("settings.profile.username")} value={String(user?.username ?? "—")} />
+          <InfoRow label={t("settings.profile.fullName")} value={String(user?.full_name ?? "—")} />
+          <InfoRow label={t("settings.profile.organization")} value={String(user?.organization ?? "—")} />
+        </div>
+      </section>
+
+      <div className="ss-settings-grid">
+        <section className="card">
+          <div className="panel-title">{t("settings.tabs.profile")}</div>
+          <div className="panel-subtitle">
+            {isZh
+              ? "保持研究者身份信息在实验、导出结果与共享工作空间中的一致性。"
+              : "Keep your researcher identity consistent across simulations, exports, and shared workspace surfaces."}
+          </div>
+          <div className="ss-settings-info-grid">
+            <InfoRow label={t("settings.profile.email")} value={String(user?.email ?? "—")} />
+            <InfoRow label={t("settings.profile.username")} value={String(user?.username ?? "—")} />
+            <InfoRow label={t("settings.profile.fullName")} value={String(user?.full_name ?? "—")} />
+            <InfoRow label={t("settings.profile.organization")} value={String(user?.organization ?? "—")} />
+          </div>
+        </section>
+
+        <section className="card">
+          <div className="panel-title">{t("settings.workspaceTitle")}</div>
+          <div className="panel-subtitle">{t("settings.workspaceHint")}</div>
+          <div className="ss-settings-stack">
+            <div className="ss-pill ss-pill--quiet">
+              <Shield size={14} />
+              <span>{isZh ? "已验证的工作空间访问" : "Authenticated workspace access"}</span>
+            </div>
+            <div className="ss-pill ss-pill--quiet">
+              <Database size={14} />
+              <span>
+                {isZh
+                  ? "身份信息会复用于已保存实验"
+                  : "Profile values are reused across saved simulations"}
+              </span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+
+  const renderSecurity = () => (
+    <div className="ss-settings-grid">
+      <section className="card">
+        <div className="panel-title">{t("settings.security.sessionsTitle")}</div>
+        <div className="panel-subtitle">{t("settings.security.placeholder")}</div>
+        <button type="button" className="ss-button-danger" onClick={() => clearSession()}>
+          <LogOut size={15} />
+          <span>{t("settings.security.signoutAll")}</span>
+        </button>
+      </section>
+
+      <section className="card">
+        <div className="panel-title">{t("settings.security.controlTitle")}</div>
+        <div className="panel-subtitle">{t("settings.security.controlHint")}</div>
+        <div className="ss-settings-note">
+            {isZh
+            ? "认证流程仍然连接到 Future of Society 当前后端与 token 刷新链路。"
+            : "Authentication flows remain connected to the current Future of Society backend and token refresh chain."}
+          </div>
+        </section>
+    </div>
+  );
+
+  const renderProviders = () => (
+    <ProviderManagementPage />
+  );
+
+  const renderSearchProviders = () => (
+    <div className="ss-settings-grid ss-settings-grid--split">
+      <section className="card">
+        <div className="panel-title">{t("settings.providers.searchTitle")}</div>
+        <div className="panel-subtitle">
+          {isZh
+            ? "让检索服务与同一个研究工作空间和访问模型保持一致。"
+            : "Keep retrieval services aligned with the same research workspace and access model."}
+        </div>
+        <div className="ss-settings-info-grid">
+          <InfoRow label={t("settings.providers.fields.provider")} value={searchProvider?.provider || "—"} />
+          <InfoRow label={t("settings.providers.fields.baseUrl")} value={searchProvider?.base_url || "—"} />
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="panel-title">{t("settings.providers.setSearchProvider")}</div>
+        <div className="ss-settings-form-grid">
+          <label>
+            <span className="ss-form-label">{t("settings.providers.fields.provider")}</span>
+            <AppSelect
+              value={searchDraft.provider}
+              options={[
+                { value: "ddg", label: t("settings.providers.searchEngine.ddg") },
+                { value: "serpapi", label: t("settings.providers.searchEngine.serpapi") },
+                { value: "serper", label: t("settings.providers.searchEngine.serper") },
+                { value: "tavily", label: t("settings.providers.searchEngine.tavily") },
+                { value: "mock", label: "Mock" },
+              ]}
+              onChange={(value) => setSearchDraft((prev) => ({ ...prev, provider: value }))}
+            />
+          </label>
+
+          {(searchDraft.provider === "serpapi" ||
+            searchDraft.provider === "serper" ||
+            searchDraft.provider === "tavily") && (
+            <>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.fields.baseUrl")}</span>
+                <input
+                  value={searchDraft.base_url}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({ ...prev, base_url: event.target.value }))
+                  }
+                />
+              </label>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.fields.apiKey")}</span>
+                <input
+                  value={searchDraft.api_key}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({ ...prev, api_key: event.target.value }))
+                  }
+                />
+              </label>
+            </>
+          )}
+
+          {searchDraft.provider === "ddg" && (
+            <>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.search.region")}</span>
+                <input
+                  value={String((searchDraft.config as any).region || "")}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({
+                      ...prev,
+                      config: { ...(prev.config || {}), region: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.search.safeSearch")}</span>
+                <input
+                  value={String((searchDraft.config as any).safesearch || "moderate")}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({
+                      ...prev,
+                      config: { ...(prev.config || {}), safesearch: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+            </>
+          )}
+
+          {searchDraft.provider === "tavily" && (
+            <>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.search.searchDepth")}</span>
+                <AppSelect
+                  value={String((searchDraft.config as any).search_depth || "basic")}
+                  options={[
+                    { value: "basic", label: "basic" },
+                    { value: "advanced", label: "advanced" },
+                  ]}
+                  onChange={(value) =>
+                    setSearchDraft((prev) => ({
+                      ...prev,
+                      config: { ...(prev.config || {}), search_depth: value },
+                    }))
+                  }
+                />
+              </label>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.search.topic")}</span>
+                <input
+                  value={String((searchDraft.config as any).topic || "")}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({
+                      ...prev,
+                      config: { ...(prev.config || {}), topic: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.search.days")}</span>
+                <input
+                  type="number"
+                  min={1}
+                  value={Number((searchDraft.config as any).days || 7)}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({
+                      ...prev,
+                      config: { ...(prev.config || {}), days: Number(event.target.value || 0) },
+                    }))
+                  }
+                />
+              </label>
+              <label>
+                <span className="ss-form-label">{t("settings.providers.search.includeDomains")}</span>
+                <input
+                  value={String((searchDraft.config as any).include_domains || "")}
+                  onChange={(event) =>
+                    setSearchDraft((prev) => ({
+                      ...prev,
+                      config: { ...(prev.config || {}), include_domains: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+            </>
           )}
         </div>
 
-        {/* LLM Providers: list above, add form below */}
-        {activeTab === 'providers_llm' && (
-          <>
-            {/* List (no outer card) */}
-            <div className="card" style={{ display: 'grid', gap: 0, padding: 'var(--ss-space-0-5) var(--ss-gap-lg)' }}>
-              {providersQuery.isLoading && <div>{t('settings.providers.loading')}</div>}
-              {providersQuery.error && <div style={{ color: "var(--ss-error-400)" }}>{t('settings.providers.error')}</div>}
-              {(providersQuery.data ?? []).map((provider, idx) => {
-                const active = provider.is_active;
-                return (
-                  <div key={provider.id} style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center', padding: 'var(--ss-space-2) 0' }}>
-                    <div style={{ minWidth: 0 }}>
-                      <div style={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis' }}>{provider.name}</div>
-                      <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-sm)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                        {provider.provider} · {provider.model} · {provider.base_url || '-'}
-                      </div>
-                    </div>
-                    <div style={{ display: 'flex', gap: 'var(--ss-gap-xs)', alignItems: 'center' }}>
-                      {testHints[provider.id] && (
-                        <span style={{ fontSize: 'var(--ss-type-xs)', color: testHints[provider.id].ok ? 'var(--ss-success-400)' : 'var(--ss-error-400)' }}>
-                          {testHints[provider.id].ok ? '✓' : '✕'} {testHints[provider.id].msg}
-                        </span>
-                      )}
+        <button
+          type="button"
+          className="ss-button"
+          onClick={() => upsertSearch.mutate()}
+          disabled={upsertSearch.isPending}
+        >
+          {upsertSearch.isPending ? <span className="spinner" aria-hidden /> : <FilePlusIcon />}
+          <span>{t("settings.providers.save")}</span>
+        </button>
+      </section>
+    </div>
+  );
+
+  const renderFiles = () => (
+    <div className="ss-settings-section">
+      <div className="ss-settings-grid">
+        <SettingsMetric
+          label={isZh ? "文件数量" : "Files"}
+          value={String(uploads.length)}
+          icon={<FileStack size={16} />}
+        />
+        <SettingsMetric
+          label={isZh ? "孤立文件扫描" : "Orphan scan"}
+          value={orphanResult ? String(orphanResult.orphaned.length) : "—"}
+          icon={<Database size={16} />}
+        />
+      </div>
+
+      <section className="card">
+        <div className="panel-title">{t("settings.files.title")}</div>
+        <div className="panel-subtitle">{t("settings.files.description")}</div>
+
+        {filesQuery.isLoading ? <div>{t("settings.files.loading")}</div> : null}
+        {filesQuery.error ? <div>{t("settings.files.error")}</div> : null}
+
+        {uploads.length ? (
+          <div className="ss-data-table-wrap">
+            <table className="ss-data-table">
+              <thead>
+                <tr>
+                  <th>{t("settings.files.table.filename")}</th>
+                  <th>{t("settings.files.table.type")}</th>
+                  <th>{t("settings.files.table.size")}</th>
+                  <th>{t("settings.files.table.created")}</th>
+                  <th>{t("settings.files.table.actions")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {uploads.map((file) => (
+                  <tr key={file.id}>
+                    <td title={file.filename}>{file.filename}</td>
+                    <td>{file.type || "-"}</td>
+                    <td>{formatSize(file.size)}</td>
+                    <td>{formatDate(file.created)}</td>
+                    <td className="ss-data-table__actions">
                       <button
                         type="button"
                         className="icon-button square"
-                        title={t('settings.providers.test')}
-                        aria-label={t('settings.providers.test')}
-                        onClick={() => testProvider.mutate(provider.id)}
-                        disabled={testingId !== null}
-                        style={{ borderColor: 'var(--border)', color: 'var(--ss-info-600)' }}
-                      >
-                        {testingId === provider.id ? <span className="spinner" aria-hidden /> : <Link2Icon />}
-                      </button>
-                      <button
-                        type="button"
-                        className="icon-button square"
-                        title={active ? (t('settings.providers.activeTag') || 'Active') : (t('settings.providers.makeActive') || 'Use')}
-                        aria-label={active ? (t('settings.providers.activeTag') || 'Active') : (t('settings.providers.makeActive') || 'Use')}
-                        onClick={() => !active && activateProvider.mutate(provider.id)}
-                        disabled={active || activateProvider.isPending}
-                        style={{ borderColor: 'var(--border)', color: 'var(--ss-warning-600)' }}
-                      >
-                        {active ? <StarFilledIcon /> : <StarIcon />}
-                      </button>
-                      <button
-                        type="button"
-                        className="icon-button square"
-                        title={t('saved.delete')}
-                        aria-label={t('saved.delete')}
+                        title={t("settings.files.delete")}
+                        aria-label={t("settings.files.delete")}
                         onClick={() => {
-                          if (active) {
-                            const msg = t('settings.providers.deleteActiveConfirm') || 'This provider is active. Delete anyway?';
-                            if (!window.confirm(msg)) return;
+                          if (window.confirm(t("settings.files.deleteConfirm"))) {
+                            deleteFile.mutate(file.id);
                           }
-                          deleteProvider.mutate(provider.id);
                         }}
-                        disabled={deleteProvider.isPending}
-                        style={{ borderColor: 'var(--border)', color: 'var(--ss-error-500)' }}
+                        disabled={deleteFile.isPending}
                       >
                         <TrashIcon />
                       </button>
-                    </div>
-                    {idx < (providersQuery.data?.length || 0) - 1 && <div style={{ gridColumn: '1 / -1', borderTop: '1px solid var(--border)', margin: '0.4rem 0 0 0', opacity: 0.8 }} />}
-                  </div>
-                );
-              })}
-              {(providersQuery.data ?? []).length === 0 && <div style={{ color: "var(--ss-text-muted)" }}>{t('settings.providers.none')}</div>}
-            </div>
-
-            {/* Add form */}
-            <form onSubmit={handleCreateProvider} className="card" style={{ gap: "var(--ss-space-1)", padding: '0.45rem 0.55rem', marginTop: 'var(--ss-gap-lg)', fontSize: 'var(--ss-type-sm)' }}>
-              <h2 style={{ margin: 0, fontSize: "var(--ss-type-md)" }}>{t('settings.providers.add')}</h2>
-              <label>
-                {t('settings.providers.fields.label')}
-                <input className="input small"
-                  required
-                  value={providerDraft.name}
-                  onChange={(event) => setProviderDraft((prev) => ({ ...prev, name: event.target.value }))}
-                />
-              </label>
-              <label>
-                {t('settings.providers.fields.provider')}
-                <AppSelect
-                  value={providerDraft.provider}
-                  options={[
-                    { value: 'openai', label: t('settings.providers.type.openai') },
-                    { value: 'gemini', label: t('settings.providers.type.gemini') },
-                  ]}
-                  onChange={(val) => setProviderDraft((prev) => ({ ...prev, provider: val, base_url: val === 'openai' ? 'https://api.openai.com/v1' : '' }))}
-                  size="small"
-                />
-              </label>
-              <label>
-                {t('settings.providers.fields.model')}
-                <input className="input small"
-                  required
-                  value={providerDraft.model}
-                  onChange={(event) => setProviderDraft((prev) => ({ ...prev, model: event.target.value }))}
-                />
-              </label>
-              <label>
-                {t('settings.providers.fields.baseUrl')}
-                <input className="input small"
-                  required
-                  value={providerDraft.base_url}
-                  onChange={(event) => setProviderDraft((prev) => ({ ...prev, base_url: event.target.value }))}
-                />
-              </label>
-              <label>
-                {t('settings.providers.fields.apiKey')}
-                <div style={{ display: "flex", gap: "var(--ss-space-2)", alignItems: "center", marginTop: "0.5rem" }}>
-                  <input
-                    required
-                    type={keyVisible ? "text" : "password"}
-                    className="input small"
-                    value={providerDraft.api_key}
-                    onChange={(event) => setProviderDraft((prev) => ({ ...prev, api_key: event.target.value }))}
-                    style={{ flex: 1 }}
-                  />
-                  <button
-                    type="button"
-                    className="icon-button square"
-                    title={keyVisible ? (t('common.hide') || 'Hide') : (t('common.show') || 'Show')}
-                    aria-label={keyVisible ? (t('common.hide') || 'Hide') : (t('common.show') || 'Show')}
-                    onClick={() => setKeyVisible((prev) => !prev)}
-                  >
-                    {keyVisible ? <EyeClosedIcon /> : <EyeOpenIcon />}
-                  </button>
-                </div>
-              </label>
-              {createProvider.error && <div style={{ color: "var(--ss-error-400)" }}>{t('settings.providers.createFailed') || 'Failed to add provider.'}</div>}
-              <button
-                type="submit"
-                className="icon-button square"
-                title={t('settings.providers.save')}
-                aria-label={t('settings.providers.save')}
-                disabled={createProvider.isPending}
-                style={{ color: 'var(--ss-success-500)' }}
-              >
-                {createProvider.isPending ? <span className="spinner" aria-hidden /> : <FilePlusIcon />}
-              </button>
-            </form>
-
-            <div className="card" style={{ padding: 'var(--ss-gap-lg) var(--ss-gap-xl)', display: 'grid', gap: 'var(--ss-gap-sm)' }}>
-              <div className="panel-subtitle" style={{ margin: 0 }}>{t('settings.providers.capabilities.title')}</div>
-              <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-md)' }}>{t('settings.providers.capabilities.hint')}</div>
-              <div style={{ display: 'grid', gap: 'var(--ss-space-2)' }}>
-                {getCapabilityRows(t).map((row) => (
-                  <div key={row.model} style={{ border: '1px solid var(--border)', borderRadius: 'var(--ss-radius-md)', padding: 'var(--ss-gap-lg) var(--ss-gap-xl)', background: 'rgba(255,255,255,0.02)', display: 'grid', gap: 'var(--ss-gap-xs)' }}>
-                    <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--ss-gap-lg)', flexWrap: 'wrap' }}>
-                      <div style={{ minWidth: 0 }}>
-                        <div style={{ fontWeight: 700, fontSize: 'var(--ss-type-input)' }}>{row.model}</div>
-                        <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-md)' }}>{t('settings.providers.capabilities.modalities')}: {row.modalities}</div>
-                      </div>
-                      <div style={{ display: 'flex', gap: 'var(--ss-gap-xs)', flexWrap: 'wrap' }}>
-                        <span className="pill" style={{ background: 'var(--ss-info-soft)', color: 'var(--ss-info-600)', padding: '0.2rem 0.45rem', borderRadius: 'var(--ss-radius-pill)', fontSize: 'var(--ss-type-sm)' }}>
-                          {t('settings.providers.capabilities.context')}: {row.context}
-                        </span>
-                        <span className="pill" style={{ background: 'var(--ss-success-soft)', color: 'var(--ss-success-600)', padding: '0.2rem 0.45rem', borderRadius: 'var(--ss-radius-pill)', fontSize: 'var(--ss-type-sm)' }}>
-                          {t('settings.providers.capabilities.input')}: {row.input}
-                        </span>
-                        <span className="pill" style={{ background: 'var(--ss-warning-soft)', color: 'var(--ss-warning-600)', padding: '0.2rem 0.45rem', borderRadius: 'var(--ss-radius-pill)', fontSize: 'var(--ss-type-sm)' }}>
-                          {t('settings.providers.capabilities.output')}: {row.output}
-                        </span>
-                      </div>
-                    </div>
-                    <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-md)' }}>
-                      {t('settings.providers.capabilities.note')}: {t(row.note)}
-                    </div>
-                  </div>
+                    </td>
+                  </tr>
                 ))}
-              </div>
-              <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-sm)' }}>{t('settings.providers.capabilities.disclaimer')}</div>
-            </div>
-          </>
-        )}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
 
-        {/* Search Providers */}
-        {activeTab === 'providers_search' && (
-          <>
-            <div className="card" style={{ padding: 'var(--ss-gap-lg) var(--ss-gap-xl)', display: 'grid', gap: 'var(--ss-space-1)' }}>
-              <div className="panel-subtitle" style={{ margin: 0 }}>{t('settings.providers.searchTab') || 'Search providers'}</div>
-              <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', columnGap: 'var(--ss-space-2)', rowGap: '0.2rem', alignItems: 'baseline', fontSize: 'var(--ss-type-md)', lineHeight: 1.25 }}>
-                <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-xs)', whiteSpace: 'nowrap' }}>{t('settings.providers.fields.provider')}</div>
-                <div>{searchProvider ? (searchProvider.provider || '-') : '-'}</div>
-                <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-xs)', whiteSpace: 'nowrap' }}>{t('settings.providers.fields.baseUrl')}</div>
-                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{searchProvider ? (searchProvider.base_url || '-') : '-'}</div>
-              </div>
-            </div>
-            <div className="card" style={{ gap: "0.3rem", padding: 'var(--ss-space-2) var(--ss-gap-lg)', fontSize: 'var(--ss-type-sm)' }}>
-              <h2 style={{ margin: 0, fontSize: "var(--ss-type-md)" }}>{t('settings.providers.setSearchProvider')}</h2>
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--ss-space-2)" }}>
-                <label>
-                  {t('settings.providers.fields.provider')}
-                  <AppSelect
-                    value={searchDraft.provider}
-                    options={[
-                      { value: "ddg", label: t('settings.providers.searchEngine.ddg') },
-                      { value: "serpapi", label: t('settings.providers.searchEngine.serpapi') },
-                      { value: "serper", label: t('settings.providers.searchEngine.serper') },
-                      { value: "tavily", label: t('settings.providers.searchEngine.tavily') },
-                      { value: "mock", label: "Mock" },
-                    ]}
-                    onChange={(val) => setSearchDraft((p) => ({ ...p, provider: val }))}
-                    size="small"
-                  />
-                </label>
-                {(searchDraft.provider === "serpapi" || searchDraft.provider === "serper" || searchDraft.provider === "tavily") && (
-                  <>
-                    <label>
-                      {t('settings.providers.fields.baseUrl')}
-                      <input className="input small" value={searchDraft.base_url} onChange={(e) => setSearchDraft((p) => ({ ...p, base_url: e.target.value }))} />
-                    </label>
-                    <label>
-                      {t('settings.providers.fields.apiKey')}
-                      <input className="input small" value={searchDraft.api_key} onChange={(e) => setSearchDraft((p) => ({ ...p, api_key: e.target.value }))} />
-                    </label>
-                  </>
-                )}
-                {searchDraft.provider === "ddg" && (
-                  <>
-                    <label>
-                      {t('settings.providers.search.region')}
-                      <input className="input small" value={String((searchDraft.config as any).region || "")} onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), region: e.target.value } }))} />
-                    </label>
-                    <label>
-                      {t('settings.providers.search.safeSearch')}
-                      <input className="input small" value={String((searchDraft.config as any).safesearch || "moderate")} onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), safesearch: e.target.value } }))} />
-                    </label>
-                  </>
-                )}
-                {searchDraft.provider === "tavily" && (
-                  <>
-                    <label>
-                      {t('settings.providers.search.searchDepth')}
-                      <AppSelect
-                        value={String((searchDraft.config as any).search_depth || "basic")}
-                        options={[
-                          { value: "basic", label: "basic" },
-                          { value: "advanced", label: "advanced" },
-                        ]}
-                        onChange={(val) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), search_depth: val } }))}
-                        size="small"
-                      />
-                    </label>
-                    <label>
-                      {t('settings.providers.search.includeAnswer')}
-                      <input
-                        type="checkbox"
-                        checked={Boolean((searchDraft.config as any).include_answer || false)}
-                        onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), include_answer: e.target.checked } }))}
-                      />
-                    </label>
-                    <label>
-                      {t('settings.providers.search.topic')}
-                      <input
-                        className="input small"
-                        value={String((searchDraft.config as any).topic || "")}
-                        onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), topic: e.target.value } }))}
-                      />
-                    </label>
-                    <label>
-                      {t('settings.providers.search.days')}
-                      <input
-                        className="input small"
-                        type="number"
-                        min={1}
-                        value={Number((searchDraft.config as any).days || 7)}
-                        onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), days: Number(e.target.value || 0) } }))}
-                      />
-                    </label>
-                    <label>
-                      {t('settings.providers.search.includeDomains')}
-                      <input
-                        className="input small"
-                        value={String((searchDraft.config as any).include_domains || "")}
-                        onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), include_domains: e.target.value } }))}
-                      />
-                    </label>
-                    <label>
-                      {t('settings.providers.search.excludeDomains')}
-                      <input
-                        className="input small"
-                        value={String((searchDraft.config as any).exclude_domains || "")}
-                        onChange={(e) => setSearchDraft((p) => ({ ...p, config: { ...(p.config || {}), exclude_domains: e.target.value } }))}
-                      />
-                    </label>
-                  </>
-                )}
-                {searchDraft.provider === "mock" && (
-                  <>
-                    <div />
-                    <div />
-                  </>
-                )}
-              </div>
-              <div style={{ display: "flex", gap: "var(--ss-space-2)", alignItems: "center" }}>
-                <button
-                  type="button"
-                  className="icon-button square"
-                  title={t('settings.providers.save')}
-                  aria-label={t('settings.providers.save')}
-                  onClick={() => upsertSearch.mutate()}
-                  disabled={upsertSearch.isPending}
-                  style={{ color: 'var(--ss-success-500)' }}
-                >
-                  {upsertSearch.isPending ? <span className="spinner" aria-hidden /> : <FilePlusIcon />}
-                </button>
-                {searchProvider && (
-                  <div style={{ color: "var(--ss-text-muted)", lineHeight: 1 }}>
-                    {t('settings.providers.search.active')}: {searchProvider.provider}
-                  </div>
-
-                )}
-              </div>
-            </div>
-          </>)
-        }
-
-        {/* File Management Tab */}
-        {activeTab === 'files' && (
-          <div className="card" style={{ padding: 'var(--ss-gap-lg) var(--ss-gap-xl)', display: 'grid', gap: 'var(--ss-gap-sm)' }}>
-            <div className="panel-subtitle" style={{ margin: 0 }}>{t('settings.files.title')}</div>
-            <div style={{ color: 'var(--muted)', fontSize: 'var(--ss-type-md)' }}>{t('settings.files.description')}</div>
-
-            {filesQuery.isLoading && <div>{t('settings.files.loading')}</div>}
-            {filesQuery.error && <div style={{ color: "var(--ss-error-400)" }}>{t('settings.files.error')}</div>}
-
-            {filesQuery.data && filesQuery.data.length > 0 && (
-              <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 'var(--ss-radius-sm)' }}>
-                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--ss-type-sm)' }}>
-                  <thead style={{ background: 'rgba(0,0,0,0.02)' }}>
-                    <tr>
-                      <th style={{ padding: 'var(--ss-space-2)', textAlign: 'left', fontWeight: 600 }}>{t('settings.files.table.filename')}</th>
-                      <th style={{ padding: 'var(--ss-space-2)', textAlign: 'left', fontWeight: 600 }}>{t('settings.files.table.type')}</th>
-                      <th style={{ padding: 'var(--ss-space-2)', textAlign: 'left', fontWeight: 600 }}>{t('settings.files.table.size')}</th>
-                      <th style={{ padding: 'var(--ss-space-2)', textAlign: 'left', fontWeight: 600 }}>{t('settings.files.table.created')}</th>
-                      <th style={{ padding: 'var(--ss-space-2)', textAlign: 'right', fontWeight: 600 }}>{t('settings.files.table.actions')}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {filesQuery.data.map((file) => (
-                      <tr key={file.id} style={{ borderTop: '1px solid var(--border)' }}>
-                        <td style={{ padding: 'var(--ss-space-2)', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          <span title={file.filename}>{file.filename}</span>
-                        </td>
-                        <td style={{ padding: 'var(--ss-space-2)' }}>
-                          <span style={{ textTransform: 'uppercase', fontSize: 'var(--ss-type-label)' }}>{file.type || '-'}</span>
-                        </td>
-                        <td style={{ padding: 'var(--ss-space-2)' }}>{formatSize(file.size)}</td>
-                        <td style={{ padding: 'var(--ss-space-2)', color: 'var(--muted)' }}>{formatDate(file.created)}</td>
-                        <td style={{ padding: 'var(--ss-space-2)', textAlign: 'right' }}>
-                          <button
-                            type="button"
-                            className="icon-button square"
-                            title={t('settings.files.delete')}
-                            aria-label={t('settings.files.delete')}
-                            onClick={() => {
-                              if (window.confirm(t('settings.files.deleteConfirm'))) {
-                                deleteFile.mutate(file.id);
-                              }
-                            }}
-                            disabled={deleteFile.isPending}
-                            style={{ borderColor: 'var(--border)', color: 'var(--ss-error-500)' }}
-                          >
-                            <TrashIcon />
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-
-            {filesQuery.data && filesQuery.data.length === 0 && (
-              <div style={{ color: "var(--ss-text-muted)" }}>{t('settings.files.empty')}</div>
-            )}
-
-            <div style={{ display: 'flex', gap: 'var(--ss-space-2)', alignItems: 'center' }}>
-              <button
-                type="button"
-                className="button"
-                onClick={async () => {
-                  setFindingOrphans(true);
-                  try {
-                    const result = await findOrphans();
-                    setOrphanResult(result);
-                  } catch (err) {
-                    console.error(err);
-                  } finally {
-                    setFindingOrphans(false);
-                  }
-                }}
-                disabled={findingOrphans}
-              >
-                {findingOrphans ? '...' : t('settings.files.findOrphans')}
-              </button>
-
-              {orphanResult && (
-                <span style={{ fontSize: 'var(--ss-type-sm)', color: 'var(--muted)' }}>
-                  {orphanResult.orphaned.length > 0
-                    ? t('settings.files.orphansFound', { count: orphanResult.orphaned.length })
-                    : t('settings.files.noOrphans')}
-                </span>
-              )}
+        {!uploads.length && !filesQuery.isLoading ? (
+          <div className="ss-empty-state ss-inset">
+            <div className="panel-title">{t("settings.files.empty")}</div>
+            <div className="panel-subtitle">
+              {isZh
+                ? "上传的研究文件会在关联到实验后显示在这里。"
+                : "Uploaded research files will appear here once they are attached to simulations."}
             </div>
           </div>
-        )}
-      </div>
+        ) : null}
+      </section>
 
-    );
-  }, [activeTab, user, providerDraft, providersQuery, createProvider, testProvider, clearSession, keyVisible, filesQuery, deleteFile, t, formatSize, formatDate, orphanResult, findingOrphans]);
+      <section className="card">
+        <div className="panel-title">{t("settings.files.maintenanceTitle")}</div>
+        <div className="panel-subtitle">{t("settings.files.maintenanceHint")}</div>
+        <div className="ss-settings-action-row">
+          <button
+            type="button"
+            className="ss-button-secondary"
+            onClick={async () => {
+              setFindingOrphans(true);
+              const result = await findOrphans();
+              setOrphanResult(result);
+              setFindingOrphans(false);
+            }}
+            disabled={findingOrphans}
+          >
+            {findingOrphans ? "…" : t("settings.files.findOrphans")}
+          </button>
+          <span className="panel-subtitle">
+            {orphanResult
+              ? orphanResult.orphaned.length > 0
+                ? t("settings.files.orphansFound", { count: orphanResult.orphaned.length })
+                : t("settings.files.noOrphans")
+              : t("settings.files.noOrphans")}
+          </span>
+        </div>
+      </section>
+    </div>
+  );
+
+  const renderActiveTab = () => {
+    if (activeTab === "profile") return renderProfile();
+    if (activeTab === "security") return renderSecurity();
+    if (activeTab === "providers_llm") return renderProviders();
+    if (activeTab === "providers_search") return renderSearchProviders();
+    return renderFiles();
+  };
 
   return (
-    <div style={{ height: "100%", overflow: "auto" }}>
-      <TitleCard title={t('settings.title')} />
-      <div className="tab-layout">
-        <nav className="tab-nav">
-          <button type="button" className={`tab-button ${activeTab === "profile" ? "active" : ""}`} onClick={() => setActiveTab("profile")}>
-            {t('settings.tabs.profile')}
-          </button>
-          <button type="button" className={`tab-button ${activeTab === "security" ? "active" : ""}`} onClick={() => setActiveTab("security")}>
-            {t('settings.tabs.security')}
-          </button>
-          <button type="button" className={`tab-button ${activeTab === "providers_llm" ? "active" : ""}`} onClick={() => setActiveTab("providers_llm")}>
-            {t('settings.tabs.llmProviders') || t('settings.providers.llmTab')}
-          </button>
-          <button type="button" className={`tab-button ${activeTab === "providers_search" ? "active" : ""}`} onClick={() => setActiveTab("providers_search")}>
-            {t('settings.tabs.searchProviders') || t('settings.providers.searchTab')}
-          </button>
-          <button type="button" className={`tab-button ${activeTab === "files" ? "active" : ""}`} onClick={() => setActiveTab("files")}>
-            {t('settings.tabs.files')}
-          </button>
+    <div className="ss-product-page ss-product-page--settings scroll-panel">
+      <TitleCard title={t("settings.title")} />
+
+      <div className="tab-layout ss-settings-page__layout">
+        <nav className="tab-nav ss-settings-page__nav">
+          {tabItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`tab-button ss-settings-page__tab ${activeTab === item.id ? "active" : ""}`}
+              onClick={() => selectTab(item.id)}
+            >
+              <span className="ss-settings-page__tab-icon">{item.icon}</span>
+              <span className="ss-settings-page__tab-copy">
+                <strong>{item.title}</strong>
+                <span>{item.hint}</span>
+              </span>
+            </button>
+          ))}
         </nav>
-        <section>{tabContent}</section>
+        <section className="ss-settings-page__content">{renderActiveTab()}</section>
       </div>
     </div>
   );
 }
-
-// (Radix-based AppSelect replaces local FancySelect)

--- a/frontend/styles/pages/auth.css
+++ b/frontend/styles/pages/auth.css
@@ -14,9 +14,10 @@
     display: grid;
     min-height: 100vh;
     width: 100%;
+    margin: 0;
     grid-template-columns:
-      minmax(0, 1.08fr)
-      minmax(calc(420px * var(--ss-density-scale)), 0.92fr);
+      minmax(0, 1fr)
+      minmax(calc(420px * var(--ss-density-scale)), calc(480px * var(--ss-density-scale)));
     grid-template-rows: auto 1fr;
   }
 
@@ -25,8 +26,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--ss-space-4);
-    padding: 1rem clamp(1.2rem, 3vw, 2.8rem);
+    gap: 1rem;
+    padding: 0.8rem clamp(1rem, 2.4vw, 2.2rem);
     border-bottom: 1px solid var(--ss-border);
     background: color-mix(in srgb, var(--ss-page-surface) 88%, transparent);
     backdrop-filter: blur(14px);
@@ -35,15 +36,44 @@
   .ss-auth__topbar-brand {
     display: inline-flex;
     align-items: center;
-    gap: 0.9rem;
+    gap: 0;
     color: inherit;
     text-decoration: none;
+  }
+
+  .ss-auth__topbar-brand .ss-fos-brand__icon {
+    width: 2.7rem;
+    height: 2.7rem;
+    border-radius: 17px;
+  }
+
+  .ss-auth__topbar-brand .ss-fos-brand__title {
+    font-size: 1rem;
+  }
+
+  .ss-auth__topbar-nav {
+    display: none;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  .ss-auth__topbar-nav a {
+    color: var(--ss-text-muted);
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    text-decoration: none;
+  }
+
+  .ss-auth__topbar-nav a:hover {
+    color: var(--ss-heading);
   }
 
   .ss-auth__topbar-controls {
     display: flex;
     align-items: center;
-    gap: var(--ss-space-3);
+    gap: 0.75rem;
   }
 
   .ss-auth__utility-button {
@@ -74,7 +104,7 @@
     display: none;
     overflow: hidden;
     grid-row: 2;
-    padding: 2.8rem clamp(2rem, 4vw, 4.5rem);
+    padding: clamp(2.1rem, 3.2vw, 3.1rem) clamp(1.6rem, 3.2vw, 3.3rem);
     border-right: 1px solid var(--ss-border);
   }
 
@@ -107,12 +137,79 @@
     height: 100%;
     flex-direction: column;
     justify-content: center;
-    gap: 1.75rem;
   }
 
-  .ss-auth__hero-body {
+  .ss-auth__hero-frame {
+    width: min(760px, 100%);
     display: grid;
-    gap: 1.6rem;
+    gap: 1.8rem;
+  }
+
+  .ss-auth__hero-surface {
+    display: grid;
+    gap: 1.25rem;
+    padding: 1rem 0.2rem;
+  }
+
+  .ss-auth__hero-main {
+    display: grid;
+    gap: 0.7rem;
+    max-width: 46rem;
+  }
+
+  .ss-auth__hero-display {
+    margin: 0;
+    color: var(--ss-brand-primary);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 4.5vw, 5.4rem);
+    line-height: 0.9;
+    letter-spacing: -0.055em;
+    font-weight: 800;
+  }
+
+  .ss-auth__hero-accent {
+    margin: 0;
+    color: var(--ss-brand-primary);
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .ss-auth__hero-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+  }
+
+  .ss-auth__hero-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.72rem 1.05rem;
+    border-radius: 999px;
+    border: 1px solid var(--ss-border);
+    text-decoration: none;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .ss-auth__hero-action--primary {
+    border-color: color-mix(in srgb, var(--ss-brand-primary) 30%, var(--ss-border));
+    background: var(--ss-brand-primary);
+    color: #fff8eb;
+  }
+
+  .ss-auth__hero-action--ghost {
+    color: var(--ss-heading);
+    background: color-mix(in srgb, var(--ss-page-surface) 94%, transparent);
+  }
+
+  .ss-auth__hero-action--ghost:hover {
+    border-color: color-mix(in srgb, var(--ss-brand-primary) 24%, var(--ss-border));
   }
 
   .ss-auth__brand-mark {
@@ -138,7 +235,7 @@
   .ss-auth__hero-badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--ss-space-2);
+    gap: 0.5rem;
     padding: 0.42rem 0.88rem;
     border-radius: 999px;
     border: 1px solid var(--ss-border);
@@ -148,6 +245,7 @@
     font-weight: 600;
     letter-spacing: 0.16em;
     text-transform: uppercase;
+    justify-self: start;
   }
 
   .ss-auth__hero-badge-dot {
@@ -158,11 +256,11 @@
   }
 
   .ss-auth__hero-title {
-    max-width: 36rem;
+    max-width: none;
     font-family: var(--font-display);
-    font-size: clamp(2.8rem, 4vw, 4.6rem);
-    line-height: 1;
-    letter-spacing: -0.06em;
+    font-size: clamp(3.2rem, 4.4vw, 5.8rem);
+    line-height: 0.94;
+    letter-spacing: -0.055em;
     color: var(--ss-heading);
   }
 
@@ -171,56 +269,72 @@
     display: block;
   }
 
+  .ss-auth__hero-title-line--single {
+    white-space: nowrap;
+  }
+
   .ss-auth__hero-title-accent {
-    margin-top: 1rem;
+    margin-top: 0.85rem;
     color: var(--ss-brand-primary);
     font-family: "Inter", "PingFang SC", "Noto Sans SC", "Microsoft YaHei", sans-serif;
-    font-size: clamp(1.15rem, 1.8vw, 1.55rem);
-    font-style: italic;
-    font-weight: 400;
-    letter-spacing: -0.03em;
-    opacity: 0.92;
+    font-size: clamp(0.95rem, 1.3vw, 1.15rem);
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    opacity: 0.88;
+    text-transform: uppercase;
   }
 
   .ss-auth__hero-copy {
-    max-width: 34rem;
+    max-width: 38rem;
     color: var(--ss-text-muted);
-    font-size: 1.02rem;
-    line-height: 1.8;
+    font-size: 1rem;
+    line-height: 1.9;
   }
 
   .ss-auth__hero-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--ss-space-4);
+    gap: 0.75rem;
   }
 
   .ss-auth__hero-tag {
     display: inline-flex;
     align-items: center;
-    min-height: 2.2rem;
-    padding: 0.45rem 0.92rem;
+    min-height: 2.05rem;
+    padding: 0.38rem 0.78rem;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--ss-brand-soft) 36%, var(--ss-page-surface) 64%);
+    border: 1px solid color-mix(in srgb, var(--ss-brand-primary) 12%, var(--ss-border));
+    background: rgba(255, 255, 255, 0.52);
     color: var(--ss-text-muted);
     font-size: 0.74rem;
-    letter-spacing: 0.08em;
-    box-shadow: inset 0 0 0 1px rgba(94, 96, 88, 0.08);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
   }
 
-  .ss-auth__hero-surface {
+  .ss-auth__hero-panel {
     display: grid;
-    gap: var(--ss-space-4);
-    max-width: 42rem;
-    padding: 1.35rem;
-    border: 1px solid var(--ss-border);
-    border-radius: 26px;
+    gap: 1.2rem;
+    padding: 1.5rem;
+    border: 1px solid color-mix(in srgb, var(--ss-accent-warm) 14%, var(--ss-border));
+    border-radius: 32px;
     background:
-      radial-gradient(circle at top right, rgba(139, 80, 45, 0.08), transparent 34%),
-      color-mix(in srgb, var(--ss-page-surface) 86%, transparent);
+      radial-gradient(circle at top right, rgba(135, 189, 255, 0.1), transparent 26%),
+      radial-gradient(circle at bottom left, rgba(212, 162, 78, 0.12), transparent 32%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(255, 252, 247, 0.94));
+    box-shadow: 0 20px 46px rgba(49, 51, 44, 0.08);
+    backdrop-filter: blur(12px);
   }
 
-  .ss-auth__hero-surface-kicker {
+  .ss-auth__hero-panel-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+    gap: 1rem;
+    align-items: end;
+  }
+
+  .ss-auth__hero-panel-kicker {
     color: var(--ss-accent-warm);
     font-size: 0.7rem;
     font-weight: 700;
@@ -228,38 +342,97 @@
     text-transform: uppercase;
   }
 
-  .ss-auth__hero-surface-grid {
-    display: grid;
-    gap: 0.8rem;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .ss-auth__hero-surface-item {
-    display: grid;
-    gap: 0.45rem;
-    padding-top: 0.9rem;
-    border-top: 1px solid color-mix(in srgb, var(--ss-accent-warm) 16%, var(--ss-border));
-  }
-
-  .ss-auth__hero-surface-title {
+  .ss-auth__hero-panel-title {
+    margin-top: 0.35rem;
     color: var(--ss-heading);
-    font-size: 0.95rem;
+    font-family: var(--font-display);
+    font-size: clamp(1.3rem, 1.6vw, 1.7rem);
+    line-height: 1.15;
+    letter-spacing: -0.04em;
+  }
+
+  .ss-auth__hero-panel-copy {
+    color: var(--ss-text-muted);
+    font-size: 0.9rem;
+    line-height: 1.72;
+    justify-self: end;
+    max-width: 22rem;
+  }
+
+  .ss-auth__hero-panel-grid {
+    display: grid;
+    gap: 0.95rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .ss-auth__hero-entry {
+    display: grid;
+    gap: 0.85rem;
+    min-height: 186px;
+    padding: 1rem;
+    border: 1px solid color-mix(in srgb, var(--ss-accent-warm) 12%, var(--ss-border));
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.76);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  }
+
+  .ss-auth__hero-entry-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .ss-auth__hero-entry-icon {
+    display: flex;
+    width: 2.4rem;
+    height: 2.4rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    background: rgba(72, 101, 84, 0.12);
+    color: var(--ss-brand-primary);
+    flex-shrink: 0;
+  }
+
+  .ss-auth__hero-entry-index {
+    color: var(--ss-text-subtle);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .ss-auth__hero-entry-title {
+    color: var(--ss-heading);
+    font-size: 1rem;
     font-weight: 700;
     letter-spacing: -0.02em;
   }
 
-  .ss-auth__hero-surface-copy {
+  .ss-auth__hero-entry-body {
     margin: 0;
     color: var(--ss-text-muted);
     font-size: 0.84rem;
-    line-height: 1.6;
+    line-height: 1.68;
   }
 
-  .ss-auth__hero-note {
-    max-width: 38rem;
+  .ss-auth__hero-panel-footer {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+  }
+
+  .ss-auth__hero-panel-line {
+    width: 3rem;
+    height: 1px;
+    background: color-mix(in srgb, var(--ss-brand-primary) 20%, var(--ss-border));
+  }
+
+  .ss-auth__hero-panel-footer-text {
     color: var(--ss-text-subtle);
     font-size: 0.84rem;
-    line-height: 1.68;
+    line-height: 1.7;
   }
 
   .ss-auth__panel {
@@ -269,24 +442,25 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: clamp(1.8rem, 3vw, 2.8rem) 1.2rem;
+    padding: clamp(1.6rem, 3vw, 2.8rem) 1.25rem;
+    border-left: 1px solid var(--ss-border);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.12));
   }
 
   .ss-auth__panel-shell {
-    width: min(100%, calc(620px * var(--ss-density-scale)));
+    width: min(100%, calc(470px * var(--ss-density-scale)));
   }
 
   .ss-auth__card {
-    width: min(100%, calc(520px * var(--ss-density-scale)));
+    width: min(100%, calc(430px * var(--ss-density-scale)));
     margin: 0 auto;
-    padding: var(--ss-space-7);
-    border-radius: 28px;
-    border: 1px solid var(--ss-border);
-    background:
-      radial-gradient(circle at top right, rgba(139, 80, 45, 0.05), transparent 24%),
-      color-mix(in srgb, var(--ss-page-surface) 94%, transparent);
-    box-shadow: 0 18px 42px rgba(49, 51, 44, 0.08);
-    backdrop-filter: blur(14px);
+    padding: 0.25rem 0;
+    border-radius: 0;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
   }
 
   .ss-auth__card--wide {
@@ -296,8 +470,8 @@
   .ss-auth__mobile-brand {
     display: flex;
     align-items: center;
-    gap: var(--ss-space-3);
-    margin-bottom: var(--ss-space-6);
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
   }
 
   .ss-auth__label {
@@ -350,7 +524,7 @@
 
   .ss-auth__field .ss-auth__input:focus {
     background: rgba(255, 255, 255, 0.98);
-    background-color: var(--ss-neutral-0);
+    background-color: #ffffff;
     color: var(--ss-heading) !important;
     -webkit-text-fill-color: var(--ss-heading);
     box-shadow:
@@ -373,8 +547,8 @@
   }
 
   .ss-auth__footer {
-    margin-top: var(--ss-space-6);
-    padding-top: 1.25rem;
+    margin-top: 0.45rem;
+    padding-top: 1rem;
     border-top: 1px solid var(--ss-border);
     color: var(--ss-text-muted);
   }
@@ -383,7 +557,7 @@
     margin: 0;
     color: var(--ss-heading);
     font-family: var(--font-display);
-    font-size: clamp(2rem, 3vw, 2.55rem);
+    font-size: clamp(1.6rem, 2vw, 1.9rem);
     font-weight: 700;
     letter-spacing: -0.04em;
     line-height: 1.06;
@@ -392,8 +566,50 @@
   .ss-auth__copy,
   .ss-auth__footer-text {
     color: var(--ss-text-muted);
-    font-size: 0.95rem;
-    line-height: 1.8;
+    font-size: 0.82rem;
+    line-height: 1.72;
+  }
+
+  .ss-auth__login-intro .ss-auth__hero-badge {
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+  }
+
+  .ss-auth__trust-item {
+    border-radius: 10px;
+    font-size: 0.76rem;
+  }
+
+  .ss-auth__support-link strong {
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .ss-auth__footer {
+    border-top-style: dashed;
+  }
+
+  .ss-auth__login-card {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .ss-auth__login-intro {
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .ss-auth__login-form {
+    display: grid;
+    gap: 1.05rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--ss-border);
+  }
+
+  .ss-auth__field .ss-auth__input {
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--ss-page-surface) 92%, transparent);
   }
 
   .ss-auth__footer-link {
@@ -434,14 +650,14 @@
   .ss-auth__support-link {
     display: flex;
     align-items: center;
-    gap: var(--ss-gap-lg);
+    gap: 0.6rem;
     width: 100%;
     padding: 0.75rem 0.2rem;
     border: none;
     border-top: 1px solid var(--ss-border);
     background: transparent;
     color: var(--ss-text-muted);
-    font-size: var(--ss-type-md);
+    font-size: 0.9rem;
     font-weight: 500;
     text-align: left;
     transition: color 0.18s ease;
@@ -452,10 +668,10 @@
   }
 
   .ss-auth__footer-note {
-    margin-top: var(--ss-space-6);
+    margin-top: 1.5rem;
     display: flex;
     justify-content: space-between;
-    gap: var(--ss-space-4);
+    gap: 1rem;
     color: var(--ss-text-subtle);
     font-size: 0.7rem;
     text-transform: uppercase;
@@ -465,7 +681,7 @@
   .ss-auth__intro {
     display: flex;
     align-items: flex-start;
-    gap: var(--ss-space-4);
+    gap: 1rem;
   }
 
   .ss-auth__intro-mark {
@@ -483,7 +699,7 @@
 
   .ss-auth__grid {
     display: grid;
-    gap: var(--ss-space-4);
+    gap: 1rem;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -506,7 +722,7 @@
   .ss-auth__status {
     border-radius: 18px;
     padding: 0.9rem 1rem;
-    font-size: var(--ss-type-md);
+    font-size: 0.9rem;
     line-height: 1.6;
   }
 
@@ -685,11 +901,11 @@
   }
 
   .theme-dark .ss-auth .ss-auth__hero-tag,
-  .theme-dark .ss-auth,
-  .ss-auth.is-dark .ss-auth__trust-item ,
   .ss-auth.is-dark .ss-auth__hero-tag,
-  .theme-dark .ss-auth,
-  .ss-auth.is-dark .ss-auth__trust-item  {
+  .theme-dark .ss-auth .ss-auth__trust-item,
+  .ss-auth.is-dark .ss-auth__trust-item,
+  .theme-dark .ss-auth .ss-auth__login-route,
+  .ss-auth.is-dark .ss-auth__login-route {
     color: var(--ss-text-muted);
   }
 
@@ -699,15 +915,42 @@
     box-shadow: inset 0 0 0 1px rgba(130, 175, 160, 0.12);
   }
 
+  .theme-dark .ss-auth .ss-auth__login-route ,
+  .ss-auth.is-dark .ss-auth__login-route  {
+    border-color: rgba(130, 175, 160, 0.14);
+    background:
+      radial-gradient(circle at top right, rgba(47, 230, 166, 0.05), transparent 34%),
+      rgba(10, 24, 21, 0.6);
+  }
+
+  .theme-dark .ss-auth .ss-auth__login-route-icon ,
+  .ss-auth.is-dark .ss-auth__login-route-icon  {
+    border: 1px solid rgba(47, 230, 166, 0.14);
+    background: rgba(47, 230, 166, 0.1);
+    color: var(--ss-heading);
+  }
+
+  .theme-dark .ss-auth .ss-auth__login-route-title,
+  .ss-auth.is-dark .ss-auth__login-route-title {
+    color: var(--ss-heading);
+  }
+
+  .theme-dark .ss-auth .ss-auth__login-register-hint ,
+  .ss-auth.is-dark .ss-auth__login-register-hint  {
+    color: var(--ss-text-subtle);
+  }
+
   .theme-dark .ss-auth .ss-auth__card ,
   .ss-auth.is-dark .ss-auth__card  {
-    background:
-      radial-gradient(circle at top right, rgba(47, 230, 166, 0.08), transparent 28%),
-      linear-gradient(180deg, rgba(12, 30, 26, 0.94), rgba(9, 20, 18, 0.96));
-    border-color: rgba(47, 230, 166, 0.22);
-    box-shadow:
-      0 28px 72px rgba(0, 0, 0, 0.34),
-      inset 0 0 0 1px rgba(47, 230, 166, 0.06);
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
+
+  .theme-dark .ss-auth .ss-auth__panel,
+  .ss-auth.is-dark .ss-auth__panel {
+    border-left-color: rgba(130, 175, 160, 0.14);
+    background: linear-gradient(180deg, rgba(7, 17, 15, 0.42), rgba(7, 17, 15, 0.2));
   }
 
   .theme-dark .ss-auth .ss-auth__hero-title-accent ,
@@ -715,8 +958,8 @@
     color: #8ef2d1;
   }
 
-  .theme-dark .ss-auth .ss-auth__hero-surface ,
-  .ss-auth.is-dark .ss-auth__hero-surface  {
+  .theme-dark .ss-auth .ss-auth__hero-panel ,
+  .ss-auth.is-dark .ss-auth__hero-panel  {
     border-color: rgba(130, 175, 160, 0.16);
     background:
       radial-gradient(circle at top right, rgba(47, 230, 166, 0.05), transparent 34%),
@@ -724,24 +967,54 @@
     box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
   }
 
-  .theme-dark .ss-auth .ss-auth__hero-surface-kicker ,
-  .ss-auth.is-dark .ss-auth__hero-surface-kicker  {
+  .theme-dark .ss-auth .ss-auth__hero-panel-kicker ,
+  .ss-auth.is-dark .ss-auth__hero-panel-kicker  {
     color: #9decd1;
   }
 
-  .theme-dark .ss-auth .ss-auth__hero-surface-item ,
-  .ss-auth.is-dark .ss-auth__hero-surface-item  {
-    border-top-color: rgba(130, 175, 160, 0.14);
-  }
-
-  .theme-dark .ss-auth .ss-auth__hero-surface-title ,
-  .ss-auth.is-dark .ss-auth__hero-surface-title  {
+  .theme-dark .ss-auth .ss-auth__hero-panel-title ,
+  .ss-auth.is-dark .ss-auth__hero-panel-title  {
     color: var(--ss-heading);
   }
 
-  .theme-dark .ss-auth .ss-auth__hero-surface-copy ,
-  .ss-auth.is-dark .ss-auth__hero-surface-copy  {
+  .theme-dark .ss-auth .ss-auth__hero-panel-copy ,
+  .ss-auth.is-dark .ss-auth__hero-panel-copy  {
     color: var(--ss-text-muted);
+  }
+
+  .theme-dark .ss-auth .ss-auth__hero-entry ,
+  .ss-auth.is-dark .ss-auth__hero-entry  {
+    border-color: rgba(130, 175, 160, 0.14);
+    background: rgba(10, 24, 21, 0.72);
+  }
+
+  .theme-dark .ss-auth .ss-auth__hero-entry-icon ,
+  .ss-auth.is-dark .ss-auth__hero-entry-icon  {
+    border: 1px solid rgba(47, 230, 166, 0.14);
+    background: rgba(47, 230, 166, 0.1);
+    color: var(--ss-heading);
+  }
+
+  .theme-dark .ss-auth .ss-auth__hero-entry-index ,
+  .ss-auth.is-dark .ss-auth__hero-entry-index  {
+    color: var(--ss-text-subtle);
+  }
+
+  .theme-dark .ss-auth .ss-auth__hero-entry-title ,
+  .ss-auth.is-dark .ss-auth__hero-entry-title  {
+    color: var(--ss-heading);
+  }
+
+  .theme-dark .ss-auth .ss-auth__hero-entry-body,
+  .theme-dark .ss-auth .ss-auth__hero-panel-footer-text,
+  .ss-auth.is-dark .ss-auth__hero-entry-body,
+  .ss-auth.is-dark .ss-auth__hero-panel-footer-text  {
+    color: var(--ss-text-muted);
+  }
+
+  .theme-dark .ss-auth .ss-auth__hero-panel-line ,
+  .ss-auth.is-dark .ss-auth__hero-panel-line  {
+    background: rgba(130, 175, 160, 0.14);
   }
 
   .theme-dark .ss-auth .ss-auth__field .ss-auth__input ,
@@ -817,6 +1090,10 @@
       display: block;
     }
 
+    .ss-auth__topbar-nav {
+      display: inline-flex;
+    }
+
     .ss-auth__mobile-brand {
       display: none;
     }
@@ -825,6 +1102,7 @@
   @media (max-width: 819px) {
     .ss-auth-shell {
       grid-template-columns: 1fr;
+      width: 100%;
     }
 
     .ss-auth__topbar {
@@ -836,7 +1114,7 @@
     }
 
     .ss-auth__card {
-      padding: var(--ss-space-6);
+      padding: 1.5rem;
     }
 
     .ss-auth__grid {
@@ -849,6 +1127,17 @@
 
     .ss-auth__footer-note {
       flex-direction: column;
+    }
+  }
+
+  @media (max-width: 1200px) {
+    .ss-auth__hero-panel-header {
+      grid-template-columns: 1fr;
+    }
+
+    .ss-auth__hero-panel-copy {
+      justify-self: start;
+      max-width: none;
     }
   }
 

--- a/frontend/styles/pages/landing.css
+++ b/frontend/styles/pages/landing.css
@@ -2,21 +2,21 @@
 
 @layer components {
   .ss-landing {
-    --landing-bg: var(--ss-page-bg-color);
+    --landing-bg: #FFFDF8;
     --landing-surface: #F8F4EC;
     --landing-surface-strong: #FFFEF9;
-    --landing-surface-plain: var(--ss-neutral-0);
-    --landing-surface-dark: var(--ss-brand-primary);
-    --landing-surface-deep: var(--ss-brand-hover);
+    --landing-surface-plain: #ffffff;
+    --landing-surface-dark: #d4a24e;
+    --landing-surface-deep: #c4922e;
     --landing-board: rgba(255, 253, 248, 0.98);
     --landing-board-muted: rgba(248, 244, 236, 0.96);
     --landing-board-line: rgba(60, 50, 40, 0.10);
     --landing-board-card: rgba(255, 255, 255, 0.7);
-    --landing-text: var(--ss-heading);
-    --landing-muted: var(--ss-text-muted);
-    --landing-subtle: var(--ss-text-subtle);
-    --landing-accent: var(--ss-accent-warm);
-    --landing-line: var(--ss-border);
+    --landing-text: #1E1A17;
+    --landing-muted: #726D68;
+    --landing-subtle: #9B98A1;
+    --landing-accent: #87BDFF;
+    --landing-line: rgba(60, 50, 40, 0.08);
     --landing-shadow: 0 18px 42px rgba(40, 32, 20, 0.05);
     --landing-shadow-strong: 0 26px 64px rgba(40, 32, 20, 0.07);
     --landing-on-dark: #1E1A17;
@@ -25,43 +25,37 @@
     display: flex;
     min-height: calc(100vh - var(--ss-product-shell-height, 4.25rem));
     flex-direction: column;
-    gap: clamp(4rem, 5.5vw, 6.5rem);
+    gap: clamp(2.4rem, 3.8vw, 4.25rem);
     padding: clamp(0.5rem, 1.5vw, 1rem) 0 clamp(4.5rem, 7vw, 6rem);
     color: var(--landing-text);
     font-family: "Inter", "Noto Sans SC", var(--font-sans);
-    background:
-      radial-gradient(circle at 8% 0%, rgba(255, 200, 112, 0.12), transparent 28%),
-      radial-gradient(circle at 90% 0%, rgba(135, 189, 255, 0.10), transparent 26%),
-      linear-gradient(180deg, #FFFEF9 0%, #FFFDF8 100%);
+    background: linear-gradient(180deg, #fffdfa 0%, #fff9ef 100%);
   }
 
   .dark .ss-landing,
   .theme-dark .ss-landing,
   .ss-landing.is-dark {
-    --landing-bg: var(--ss-page-bg-color);
+    --landing-bg: #07110f;
     --landing-surface: rgba(10, 17, 16, 0.84);
     --landing-surface-strong: rgba(13, 23, 22, 0.94);
     --landing-surface-plain: rgba(13, 23, 22, 0.98);
-    --landing-surface-dark: var(--ss-brand-primary);
+    --landing-surface-dark: #2fe6a6;
     --landing-surface-deep: #08120f;
     --landing-board: rgba(10, 17, 16, 0.78);
     --landing-board-muted: rgba(12, 21, 20, 0.88);
     --landing-board-line: rgba(139, 170, 157, 0.12);
     --landing-board-card: rgba(18, 28, 27, 0.56);
-    --landing-text: var(--ss-heading);
+    --landing-text: #eaf7f2;
     --landing-muted: #a8c2b8;
     --landing-subtle: #6f8a81;
     --landing-accent: #8db8ab;
     --landing-line: rgba(130, 175, 160, 0.14);
     --landing-shadow: 0 18px 44px rgba(0, 0, 0, 0.28);
     --landing-shadow-strong: 0 24px 68px rgba(0, 0, 0, 0.34);
-    --landing-on-dark: var(--ss-brand-on);
+    --landing-on-dark: #05120f;
     --landing-on-dark-muted: rgba(5, 18, 15, 0.76);
     --landing-preview-shadow: 0 28px 72px rgba(0, 0, 0, 0.36);
-    background:
-      radial-gradient(circle at 10% 0%, rgba(47, 230, 166, 0.12), transparent 28%),
-      radial-gradient(circle at 82% 0%, rgba(31, 209, 194, 0.1), transparent 24%),
-      linear-gradient(180deg, #08120f 0%, #07110f 100%);
+    background: linear-gradient(180deg, #08120f 0%, #07110f 100%);
   }
 
   .ss-landing a {
@@ -94,118 +88,132 @@
 
   .ss-landing__hero-grid {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(20rem, 29rem);
-    gap: clamp(2rem, 4vw, 4rem);
-    align-items: start;
+    grid-template-columns: minmax(0, 1.08fr) minmax(18.5rem, 24.75rem);
+    gap: clamp(1.35rem, 2.8vw, 2.6rem);
+    align-items: stretch;
   }
 
   .ss-landing__hero-copy {
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 1.8rem;
-    padding-block: clamp(1rem, 2vw, 2.8rem);
+    gap: 0.85rem;
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+    border: 1px solid var(--landing-board-line);
+    border-radius: 30px;
+    background:
+      radial-gradient(circle at 100% 0%, rgba(165, 106, 67, 0.08), transparent 26%),
+      linear-gradient(180deg, color-mix(in srgb, var(--landing-surface) 98%, white 2%) 0%, color-mix(in srgb, var(--landing-board-muted) 38%, var(--landing-surface) 62%) 100%);
+    box-shadow: 0 12px 26px rgba(47, 49, 43, 0.06);
+  }
+
+  .ss-landing__hero-copy::before {
+    display: none;
+  }
+
+  .ss-landing__hero-head {
+    padding-inline: 0.35rem;
   }
 
   .ss-landing__hero-stage {
-    position: relative;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: flex-start;
+    flex: 1;
     gap: 1.65rem;
     min-height: clamp(31rem, 36vw, 36.5rem);
-    overflow: hidden;
     border: 1px solid var(--landing-board-line);
     border-radius: 24px;
-    background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(251, 249, 245, 0.92)),
-      var(--ss-landing-hero-image) center/cover no-repeat;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(251, 249, 245, 0.92));
     padding: clamp(1.65rem, 2.5vw, 2.15rem);
-    box-shadow: 0 14px 30px rgba(47, 49, 43, 0.08);
   }
 
-  .theme-dark .ss-landing .ss-landing__hero-stage,
-  .ss-landing.is-dark .ss-landing__hero-stage {
-    background:
-      linear-gradient(180deg, rgba(14, 26, 24, 0.78), rgba(10, 17, 16, 0.92)),
-      var(--ss-landing-hero-image) center/cover no-repeat;
-    border-color: rgba(139, 170, 157, 0.12);
-    box-shadow:
-      0 18px 42px rgba(0, 0, 0, 0.28),
-      inset 0 0 0 1px rgba(47, 230, 166, 0.04);
-  }
-
-  .ss-landing__hero-body,
-  .ss-landing__hero-footer {
+  .ss-landing__hero-body {
     position: relative;
     z-index: 1;
+  }
+
+  .ss-landing__eyebrow {
+    display: inline-flex;
+    width: fit-content;
+    align-items: center;
+    gap: 0.75rem;
+    color: #a27a36;
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    white-space: pre-line;
+  }
+
+  .ss-landing__eyebrow-brand .ss-fos-brand__icon {
+    width: 2.15rem;
+    height: 2.15rem;
+    border-radius: 14px;
+    box-shadow: 0 6px 14px rgba(92, 69, 31, 0.05);
   }
 
   .ss-landing__hero-body {
     display: flex;
     flex: 1;
     min-height: 0;
+    width: 100%;
+    max-width: none;
     flex-direction: column;
-    gap: 1.4rem;
-  }
-
-  .ss-landing__hero-footer {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .ss-landing__eyebrow--hero {
-    width: fit-content;
-    padding: 0.35rem 0.72rem;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.72);
-    backdrop-filter: blur(12px);
-  }
-
-  .theme-dark .ss-landing .ss-landing__eyebrow--hero,
-  .ss-landing.is-dark .ss-landing__eyebrow--hero {
-    background: rgba(10, 24, 21, 0.7);
-    color: #9decd1;
-  }
-
-  .ss-landing__eyebrow {
-    color: color-mix(in srgb, var(--landing-surface-dark) 72%, var(--landing-muted));
-    font-size: 0.82rem;
-    font-weight: 600;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+    gap: 1.6rem;
   }
 
   .ss-landing__headline-group {
     display: flex;
+    flex: 1;
+    min-height: 0;
     flex-direction: column;
-    gap: 1.2rem;
+  }
+
+  .ss-landing__title-stack {
+    display: inline-flex;
+    width: fit-content;
+    max-width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+
+  .ss-landing__hero-footer {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: end;
+    gap: 1rem 1.4rem;
+    margin-top: auto;
+    padding-top: 1rem;
+    border-top: 1px solid var(--landing-board-line);
   }
 
   .ss-landing__title {
     margin: 0;
     font-family: "Noto Sans SC", "Inter", sans-serif;
-    font-size: clamp(3.2rem, 6vw, 5.8rem);
-    line-height: 1.02;
-    font-weight: 700;
+    max-width: none;
+    font-size: clamp(3.75rem, 4.7vw, 4.7rem);
+    line-height: 0.92;
+    font-weight: 760;
     letter-spacing: -0.06em;
-    color: var(--landing-text);
+    color: #c79a45;
+    text-shadow: 0 10px 22px rgba(199, 154, 69, 0.12);
   }
 
-  .ss-landing__title-line,
-  .ss-landing__title-accent {
+  .ss-landing__title-line {
     display: block;
   }
 
   .ss-landing__title-accent {
-    margin-top: 1rem;
-    color: var(--landing-surface-dark);
-    font-family: "Inter", "Noto Sans SC", sans-serif;
-    font-size: clamp(1.45rem, 2.3vw, 2.65rem);
-    font-style: italic;
-    font-weight: 400;
-    letter-spacing: -0.04em;
-    opacity: 0.92;
+    margin: 0;
+    color: #a27a36;
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
   }
 
   .theme-dark .ss-landing .ss-landing__title-accent ,
@@ -216,16 +224,78 @@
   .ss-landing__subtitle,
   .ss-landing__section-subtitle {
     margin: 0;
-    max-width: 42rem;
+    max-width: 34rem;
     color: var(--landing-muted);
-    font-size: 1.04rem;
-    line-height: 1.88;
+    font-size: 1.12rem;
+    line-height: 1.82;
+  }
+
+  .ss-landing__hero-body .ss-landing__subtitle {
+    width: 100%;
+    max-width: none;
+    font-size: clamp(1.7rem, 2.25vw, 2.18rem);
+    line-height: 1.48;
+    font-weight: 560;
+    letter-spacing: -0.022em;
+    color: color-mix(in srgb, var(--landing-text) 80%, var(--landing-muted));
+  }
+
+  .ss-landing__hero-body .ss-landing__subtitle--dynamic {
+    position: relative;
+    display: grid;
+    gap: 0.7rem;
+    align-self: stretch;
+    padding-right: clamp(0rem, 0.6vw, 0.6rem);
+  }
+
+  .ss-landing__subtitle-segment {
+    position: relative;
+    display: block;
+    width: 100%;
+    opacity: 0;
+    transform: translateY(0.7rem);
+    filter: blur(0.7rem);
+    clip-path: inset(0 100% 0 0);
+    text-wrap: pretty;
+  }
+
+  .ss-reveal.is-visible .ss-landing__subtitle-segment {
+    animation: ss-landing-subtitle-type-in 1.15s steps(28, end) forwards;
+  }
+
+  .ss-reveal.is-visible .ss-landing__subtitle-segment:nth-child(2) {
+    animation-delay: 0.42s;
+  }
+
+  .ss-reveal.is-visible .ss-landing__subtitle-segment:nth-child(3) {
+    animation-delay: 0.84s;
+  }
+
+  .ss-reveal.is-visible .ss-landing__subtitle-segment:nth-child(4) {
+    animation-delay: 1.26s;
+  }
+
+  .ss-landing__subtitle-segment::after {
+    content: "";
+    position: absolute;
+    top: 0.2em;
+    right: -0.16rem;
+    width: 0.12rem;
+    height: 1.05em;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--landing-surface-dark) 76%, white 24%);
+    opacity: 0;
+  }
+
+  .ss-reveal.is-visible .ss-landing__subtitle-segment:last-child::after {
+    animation: ss-landing-subtitle-caret-loop 0.92s steps(1, end) 5;
   }
 
   .ss-landing__hero-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.9rem;
+    gap: 0.9rem 1rem;
+    margin-top: 0;
   }
 
   .ss-landing__button,
@@ -250,27 +320,28 @@
     align-items: center;
     justify-content: center;
     gap: 0.7rem;
-    min-height: 3.55rem;
-    padding: 0.92rem 1.55rem;
+    min-height: 3.8rem;
+    padding: 1rem 1.7rem;
     border: 1px solid transparent;
-    font-size: 0.96rem;
+    font-size: 1rem;
     font-weight: 600;
     letter-spacing: 0.01em;
   }
 
   .ss-landing__button--primary {
-    background: var(--landing-surface-strong);
-    border-color: rgba(212, 162, 78, 0.16);
-    color: var(--landing-text);
-    box-shadow: 0 14px 34px rgba(40, 32, 20, 0.06);
+    background: linear-gradient(135deg, #f3d79d 0%, #d8b064 56%, #c0913d 100%);
+    border-color: rgba(200, 162, 94, 0.34);
+    color: #2c2113;
+    box-shadow: 0 16px 34px rgba(192, 145, 61, 0.18);
   }
 
   .ss-landing__button--ghost {
     background: transparent;
-    color: var(--landing-muted);
+    color: #6e5730;
     min-height: auto;
     padding-inline: 0;
     justify-content: flex-start;
+    font-weight: 700;
   }
 
   .theme-dark .ss-landing .ss-landing__button--primary ,
@@ -295,7 +366,7 @@
   }
 
   .ss-landing__button--primary:hover {
-    box-shadow: 0 18px 42px rgba(40, 32, 20, 0.10);
+    box-shadow: 0 22px 40px rgba(192, 145, 61, 0.22);
   }
 
   .theme-dark .ss-landing .ss-landing__button--primary:hover ,
@@ -309,18 +380,19 @@
   .ss-landing__tag-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.85rem;
-    padding-top: 0.45rem;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    padding-top: 0;
   }
 
   .ss-landing__tag {
     border-radius: 999px;
-    background: var(--landing-surface);
-    padding: 0.45rem 0.92rem;
-    color: var(--landing-muted);
-    font-size: 0.74rem;
-    letter-spacing: 0.08em;
-    box-shadow: inset 0 0 0 1px rgba(94, 96, 88, 0.08);
+    background: rgba(255, 255, 255, 0.82);
+    padding: 0.52rem 1rem;
+    color: #6c665f;
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    box-shadow: inset 0 0 0 1px rgba(196, 147, 64, 0.14);
   }
 
   .theme-dark .ss-landing .ss-landing__tag ,
@@ -329,23 +401,58 @@
     box-shadow: inset 0 0 0 1px rgba(130, 175, 160, 0.12);
   }
 
+  .theme-dark .ss-landing .ss-landing__eyebrow,
+  .ss-landing.is-dark .ss-landing__eyebrow {
+    color: #d8b472;
+  }
+
+  .theme-dark .ss-landing .ss-landing__hero-copy,
+  .ss-landing.is-dark .ss-landing__hero-copy {
+    background:
+      radial-gradient(circle at top right, rgba(47, 230, 166, 0.05), transparent 28%),
+      linear-gradient(180deg, rgba(10, 17, 16, 0.72), rgba(8, 14, 13, 0.9));
+    border-color: rgba(139, 170, 157, 0.12);
+    box-shadow:
+      0 14px 34px rgba(0, 0, 0, 0.24),
+      inset 0 0 0 1px rgba(47, 230, 166, 0.03);
+  }
+
+  .theme-dark .ss-landing .ss-landing__hero-stage,
+  .ss-landing.is-dark .ss-landing__hero-stage {
+    background:
+      linear-gradient(180deg, rgba(14, 26, 24, 0.88), rgba(10, 17, 16, 0.96)),
+      radial-gradient(circle at top right, rgba(47, 230, 166, 0.08), transparent 42%);
+    border-color: rgba(139, 170, 157, 0.14);
+    box-shadow:
+      0 14px 36px rgba(0, 0, 0, 0.28),
+      inset 0 0 0 1px rgba(47, 230, 166, 0.04);
+  }
+
+  .theme-dark .ss-landing .ss-landing__title,
+  .ss-landing.is-dark .ss-landing__title {
+    color: #f0d28f;
+    text-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+  }
+
   .ss-landing__entry-board {
     min-width: 0;
+    height: 100%;
     width: 100%;
-    max-width: 29rem;
+    max-width: 24.75rem;
     justify-self: end;
   }
 
   .ss-landing__entry-board-shell {
     display: flex;
+    height: 100%;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.75rem;
     border: 1px solid var(--landing-board-line);
     border-radius: 30px;
-    padding: 1.15rem;
+    padding: 1rem;
     background:
       radial-gradient(circle at 100% 0%, rgba(165, 106, 67, 0.08), transparent 26%),
-      linear-gradient(180deg, color-mix(in srgb, var(--landing-surface) 98%, var(--ss-neutral-0) 2%) 0%, color-mix(in srgb, var(--landing-board-muted) 38%, var(--landing-surface) 62%) 100%);
+      linear-gradient(180deg, color-mix(in srgb, var(--landing-surface) 98%, white 2%) 0%, color-mix(in srgb, var(--landing-board-muted) 38%, var(--landing-surface) 62%) 100%);
     box-shadow: 0 12px 26px rgba(47, 49, 43, 0.06);
     color: var(--landing-text);
     opacity: 0.9;
@@ -385,14 +492,14 @@
 
   .ss-landing__launch-card {
     display: flex;
-    min-height: 16rem;
+    min-height: 12.25rem;
     flex-direction: column;
     justify-content: space-between;
-    gap: 1.1rem;
+    gap: 0.9rem;
     border: 1px solid var(--landing-board-line);
     border-radius: 24px;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(251, 249, 245, 0.92));
-    padding: 1.55rem;
+    padding: 1.35rem;
   }
 
   .theme-dark .ss-landing .ss-landing__launch-card ,
@@ -424,7 +531,7 @@
   .ss-landing__launch-route,
   .ss-landing__entry-path {
     color: var(--landing-on-dark-muted);
-    font-size: 0.72rem;
+    font-size: 0.68rem;
     letter-spacing: 0.04em;
   }
 
@@ -443,19 +550,19 @@
   .ss-landing__entry-matrix {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.9rem;
+    gap: 0.65rem;
   }
 
   .ss-landing__entry-tile {
     display: flex;
-    min-height: 11rem;
+    min-height: 8.75rem;
     flex-direction: column;
     justify-content: space-between;
-    gap: 0.8rem;
+    gap: 0.65rem;
     border: 1px solid var(--landing-board-line);
     border-radius: 20px;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(251, 249, 245, 0.9));
-    padding: 1.15rem;
+    padding: 1rem;
   }
 
   .theme-dark .ss-landing .ss-landing__entry-tile ,
@@ -495,7 +602,7 @@
   .ss-landing__matrix-copy {
     display: flex;
     flex-direction: column;
-    gap: var(--ss-gap-xs);
+    gap: 0.3rem;
   }
 
   .ss-landing__matrix-title,
@@ -511,7 +618,7 @@
   }
 
   .ss-landing__launch-card .ss-landing__matrix-title {
-    font-size: 1.48rem;
+    font-size: 1.34rem;
   }
 
   .ss-landing__matrix-subtitle,
@@ -526,21 +633,43 @@
   }
 
   .ss-landing__preview-band {
-    padding-block: clamp(3rem, 5vw, 5rem);
-    background: linear-gradient(180deg, rgba(248, 244, 236, 0.94), rgba(252, 250, 245, 0.82));
+    padding-block: clamp(4rem, 7vw, 7rem);
+    position: relative;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 8% 40%, rgba(212, 162, 78, 0.10) 0%, transparent 38%),
+      radial-gradient(circle at 88% 20%, rgba(135, 189, 255, 0.12) 0%, transparent 32%),
+      linear-gradient(160deg, #FFFEF9 0%, #F8F4EC 50%, #FFFDF8 100%);
   }
 
-  .theme-dark .ss-landing .ss-landing__preview-band ,
-  .ss-landing.is-dark .ss-landing__preview-band  {
+  .ss-landing__preview-band::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: none;
+    pointer-events: none;
+  }
+
+  .theme-dark .ss-landing .ss-landing__preview-band,
+  .ss-landing.is-dark .ss-landing__preview-band {
     background:
-      radial-gradient(circle at 20% 0%, rgba(47, 230, 166, 0.06), transparent 24%),
-      linear-gradient(180deg, rgba(8, 18, 15, 0.94), rgba(7, 17, 15, 0.86));
+      radial-gradient(circle at 10% 50%, rgba(28, 80, 120, 0.4) 0%, transparent 40%),
+      radial-gradient(circle at 90% 20%, rgba(20, 120, 100, 0.3) 0%, transparent 35%),
+      linear-gradient(160deg, #060e1a 0%, #08160f 50%, #060b14 100%);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-band::before,
+  .theme-dark .ss-landing .ss-landing__preview-band::before {
+    background-image: none;
+    opacity: 0;
   }
 
   .ss-landing__preview-shell {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 2.5rem;
+    position: relative;
+    z-index: 1;
   }
 
   .ss-landing__preview-head {
@@ -548,8 +677,13 @@
     align-items: end;
     justify-content: space-between;
     gap: 1.5rem;
-    border-left: 4px solid color-mix(in srgb, var(--landing-surface-dark) 80%, var(--landing-muted));
+    border-left: 4px solid rgba(212, 162, 78, 0.7);
     padding-left: 1.8rem;
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-head,
+  .theme-dark .ss-landing .ss-landing__preview-head {
+    border-left-color: rgba(47, 230, 166, 0.7);
   }
 
   .ss-landing__preview-copy {
@@ -590,13 +724,38 @@
     align-items: center;
     justify-content: center;
     gap: 0.7rem;
-    border: 1px solid transparent;
-    color: var(--landing-text);
+    border: 1px solid rgba(60, 50, 40, 0.16);
+    border-radius: 999px;
+    padding: 0.5rem 1.2rem;
+    color: var(--landing-muted);
     font-size: 0.76rem;
     font-weight: 700;
     letter-spacing: 0.16em;
     text-transform: uppercase;
     white-space: nowrap;
+    backdrop-filter: blur(10px);
+    background: rgba(255, 253, 248, 0.6);
+    transition: background 0.24s ease, border-color 0.24s ease;
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-link,
+  .theme-dark .ss-landing .ss-landing__preview-link {
+    border-color: rgba(255, 255, 255, 0.18);
+    color: rgba(255, 255, 255, 0.82);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .ss-landing__preview-link:hover {
+    background: rgba(212, 162, 78, 0.08);
+    border-color: rgba(212, 162, 78, 0.4);
+    color: var(--landing-surface-deep);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-link:hover,
+  .theme-dark .ss-landing .ss-landing__preview-link:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(47, 230, 166, 0.5);
+    color: rgba(47, 230, 166, 0.9);
   }
 
   .ss-landing__preview-link-icon {
@@ -617,61 +776,113 @@
   .ss-landing__preview-stage {
     position: relative;
     overflow: hidden;
-    border: 1px solid var(--landing-line);
-    border-radius: 28px;
-    background: var(--landing-surface-plain);
-    box-shadow: var(--landing-preview-shadow);
+    border: 1px solid rgba(60, 50, 40, 0.10);
+    border-radius: 20px;
+    background: rgba(255, 253, 248, 0.95);
+    box-shadow:
+      0 0 0 1px rgba(212, 162, 78, 0.06),
+      0 20px 48px rgba(40, 32, 20, 0.07);
   }
 
-  .theme-dark .ss-landing .ss-landing__preview-stage ,
-  .ss-landing.is-dark .ss-landing__preview-stage  {
+  .ss-landing__preview-stage--video {
+    grid-column: 1 / -1;
+    padding: 1rem;
     background:
-      radial-gradient(circle at top center, rgba(47, 230, 166, 0.05), transparent 34%),
-      rgba(8, 20, 18, 0.96);
-    border-color: rgba(139, 170, 157, 0.12);
-    box-shadow:
-      0 22px 54px rgba(0, 0, 0, 0.32),
-      inset 0 0 0 1px rgba(47, 230, 166, 0.04);
+      radial-gradient(circle at top right, rgba(212, 162, 78, 0.12), transparent 32%),
+      rgba(255, 252, 246, 0.98);
+  }
+
+  .ss-landing__preview-stage::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2.4rem;
+    background: rgba(248, 244, 236, 0.98);
+    border-bottom: 1px solid rgba(60, 50, 40, 0.07);
+    z-index: 2;
+    display: flex;
+    align-items: center;
   }
 
   .ss-landing__preview-stage::after {
     content: "";
     position: absolute;
     inset: 0;
-    background: linear-gradient(180deg, transparent 56%, rgba(49, 51, 44, 0.12) 100%);
+    background: linear-gradient(180deg, transparent 70%, rgba(248, 244, 236, 0.4) 100%);
     pointer-events: none;
+    z-index: 1;
   }
 
-  .ss-landing__preview-stage--video {
-    min-height: 34rem;
+  .ss-landing__preview-stage--video::before,
+  .ss-landing__preview-stage--video::after {
+    display: none;
   }
 
-  .ss-landing__preview-video {
-    display: block;
-    width: 100%;
-    height: 100%;
-    min-height: 34rem;
-    object-fit: cover;
-    background: #000;
+  .ss-landing.is-dark .ss-landing__preview-stage,
+  .theme-dark .ss-landing .ss-landing__preview-stage {
+    border-color: rgba(47, 230, 166, 0.22);
+    background: rgba(6, 16, 14, 0.92);
+    box-shadow:
+      0 0 0 1px rgba(47, 230, 166, 0.08),
+      0 30px 60px rgba(0, 0, 0, 0.5),
+      0 0 80px rgba(47, 230, 166, 0.06);
   }
 
-  .theme-dark .ss-landing .ss-landing__preview-video,
-  .ss-landing.is-dark .ss-landing__preview-video {
-    filter: saturate(0.94) brightness(0.88);
+  .ss-landing.is-dark .ss-landing__preview-stage--video,
+  .theme-dark .ss-landing .ss-landing__preview-stage--video {
+    background:
+      radial-gradient(circle at top right, rgba(47, 230, 166, 0.14), transparent 34%),
+      rgba(7, 17, 16, 0.96);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-stage::before,
+  .theme-dark .ss-landing .ss-landing__preview-stage::before {
+    background: rgba(10, 22, 20, 0.96);
+    border-bottom-color: rgba(47, 230, 166, 0.1);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-stage::after,
+  .theme-dark .ss-landing .ss-landing__preview-stage::after {
+    background: linear-gradient(180deg, transparent 60%, rgba(6, 16, 14, 0.6) 100%);
   }
 
   .ss-landing__preview-image {
     display: block;
     width: 100%;
     height: 100%;
-    min-height: 34rem;
+    min-height: 32rem;
     object-fit: cover;
-    opacity: 0.92;
+    object-position: top;
+    opacity: 0.9;
     transition: transform 0.7s ease;
+    margin-top: 2.8rem;
   }
 
   .ss-landing__preview-stage:hover .ss-landing__preview-image {
-    transform: scale(1.02);
+    transform: scale(1.015);
+  }
+
+  .ss-landing__preview-video {
+    display: block;
+    width: 100%;
+    min-height: min(46rem, 70vh);
+    border: 1px solid rgba(60, 50, 40, 0.08);
+    border-radius: 16px;
+    background: #000;
+    object-fit: cover;
+    box-shadow:
+      0 18px 40px rgba(40, 32, 20, 0.14),
+      0 0 0 1px rgba(212, 162, 78, 0.08);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-video,
+  .theme-dark .ss-landing .ss-landing__preview-video {
+    border-color: rgba(47, 230, 166, 0.16);
+    box-shadow:
+      0 18px 40px rgba(0, 0, 0, 0.38),
+      0 0 0 1px rgba(47, 230, 166, 0.08);
   }
 
   .ss-landing__preview-float {
@@ -720,29 +931,35 @@
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
-    border: 1px solid var(--landing-line);
-    border-radius: 24px;
-    background: rgba(255, 255, 255, 0.62);
-    padding: 1.2rem;
-    box-shadow: 0 18px 38px rgba(49, 51, 44, 0.1);
+    border: 1px solid rgba(60, 50, 40, 0.10);
+    border-radius: 20px;
+    background: rgba(255, 253, 248, 0.92);
+    padding: 1.4rem;
+    box-shadow: 0 12px 28px rgba(40, 32, 20, 0.06);
+    backdrop-filter: blur(16px);
   }
 
-  .theme-dark .ss-landing .ss-landing__preview-panel ,
-  .ss-landing.is-dark .ss-landing__preview-panel  {
-    border-color: rgba(139, 170, 157, 0.12);
-    background: rgba(10, 17, 16, 0.76);
-    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+  .ss-landing.is-dark .ss-landing__preview-panel,
+  .theme-dark .ss-landing .ss-landing__preview-panel {
+    border-color: rgba(47, 230, 166, 0.15);
+    background: rgba(8, 20, 18, 0.78);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3), inset 0 0 0 1px rgba(47, 230, 166, 0.04);
   }
 
   .ss-landing__preview-overlay-head {
     display: flex;
     justify-content: space-between;
     gap: 1rem;
-    color: var(--landing-subtle);
+    color: var(--landing-muted);
     font-size: 0.64rem;
     font-weight: 700;
     letter-spacing: 0.16em;
     text-transform: uppercase;
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-overlay-head,
+  .theme-dark .ss-landing .ss-landing__preview-overlay-head {
+    color: rgba(160, 200, 180, 0.7);
   }
 
   .ss-landing__preview-meter {
@@ -755,7 +972,12 @@
   .ss-landing__preview-meter-fill {
     width: 68%;
     height: 100%;
-    background: linear-gradient(90deg, color-mix(in srgb, var(--landing-surface-dark) 55%, var(--ss-neutral-0) 45%), var(--landing-surface-dark));
+    background: linear-gradient(90deg, rgba(212, 162, 78, 0.5), rgba(212, 140, 50, 0.9));
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-meter-fill,
+  .theme-dark .ss-landing .ss-landing__preview-meter-fill {
+    background: linear-gradient(90deg, rgba(47, 180, 140, 0.6), rgba(47, 230, 166, 0.9));
   }
 
   .ss-landing__preview-overlay-copy,
@@ -771,16 +993,16 @@
   .ss-landing__preview-signal-list {
     display: grid;
     gap: 0.7rem;
-    border: 1px solid var(--landing-line);
-    border-radius: 24px;
-    background: rgba(255, 255, 255, 0.44);
+    border: 1px solid rgba(60, 50, 40, 0.08);
+    border-radius: 16px;
+    background: rgba(248, 244, 236, 0.7);
     padding: 1.05rem 1.15rem;
   }
 
-  .theme-dark .ss-landing .ss-landing__preview-signal-list ,
-  .ss-landing.is-dark .ss-landing__preview-signal-list  {
-    border-color: rgba(130, 175, 160, 0.14);
-    background: rgba(10, 24, 21, 0.64);
+  .ss-landing.is-dark .ss-landing__preview-signal-list,
+  .theme-dark .ss-landing .ss-landing__preview-signal-list {
+    border-color: rgba(47, 230, 166, 0.1);
+    background: rgba(5, 16, 14, 0.6);
   }
 
   .ss-landing__preview-signal {
@@ -792,27 +1014,51 @@
     line-height: 1.5;
   }
 
+  .ss-landing.is-dark .ss-landing__preview-signal,
+  .theme-dark .ss-landing .ss-landing__preview-signal {
+    color: rgba(160, 200, 180, 0.75);
+  }
+
   .ss-landing__preview-signal-dot {
-    width: 0.48rem;
-    height: 0.48rem;
+    width: 0.44rem;
+    height: 0.44rem;
     border-radius: 999px;
-    background: var(--landing-surface-dark);
-    box-shadow: 0 0 0 6px rgba(47, 230, 166, 0.08);
+    flex-shrink: 0;
+    background: rgba(212, 162, 78, 0.8);
+    box-shadow: 0 0 0 4px rgba(212, 162, 78, 0.12), 0 0 8px rgba(212, 162, 78, 0.3);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-signal-dot,
+  .theme-dark .ss-landing .ss-landing__preview-signal-dot {
+    background: rgba(47, 230, 166, 0.8);
+    box-shadow: 0 0 0 4px rgba(47, 230, 166, 0.12), 0 0 8px rgba(47, 230, 166, 0.4);
   }
 
   .ss-landing__preview-link--panel {
     min-height: 3.45rem;
-    border: 1px solid rgba(94, 96, 88, 0.14);
-    border-radius: 24px;
-    background: rgba(255, 255, 255, 0.54);
+    border: 1px solid rgba(212, 162, 78, 0.22);
+    border-radius: 16px;
+    background: rgba(212, 162, 78, 0.07);
     justify-content: space-between;
     padding-inline: 1.1rem;
+    color: var(--landing-surface-deep);
+    transition: background 0.24s ease;
   }
 
-  .theme-dark .ss-landing .ss-landing__preview-link--panel ,
-  .ss-landing.is-dark .ss-landing__preview-link--panel  {
-    background: rgba(9, 20, 18, 0.72);
-    border-color: rgba(130, 175, 160, 0.14);
+  .ss-landing__preview-link--panel:hover {
+    background: rgba(212, 162, 78, 0.13);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-link--panel,
+  .theme-dark .ss-landing .ss-landing__preview-link--panel {
+    border-color: rgba(47, 230, 166, 0.2);
+    background: rgba(47, 230, 166, 0.07);
+    color: rgba(47, 230, 166, 0.85);
+  }
+
+  .ss-landing.is-dark .ss-landing__preview-link--panel:hover,
+  .theme-dark .ss-landing .ss-landing__preview-link--panel:hover {
+    background: rgba(47, 230, 166, 0.14);
   }
 
   .ss-landing__capabilities,
@@ -944,8 +1190,8 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 1.8rem 1.8rem 0;
+    overflow: hidden;
   }
-
 
   .ss-landing__capability-small-top {
     display: flex;
@@ -987,6 +1233,7 @@
     transform: scale(1.04);
     opacity: 0.95;
   }
+
   .ss-landing__capability-banner {
     grid-column: span 2;
     display: flex;
@@ -1023,7 +1270,7 @@
   .ss-landing__scene-head {
     display: flex;
     flex-direction: column;
-    gap: var(--ss-gap-xs);
+    gap: 0.35rem;
     margin-bottom: 2rem;
   }
 
@@ -1063,16 +1310,31 @@
   }
 
   .ss-landing__scene-card::before {
-    opacity: 0.88;
+    opacity: 0.18;
+    z-index: 1;
   }
 
   .ss-landing__scene-card::after {
-    background: linear-gradient(180deg, transparent 24%, rgba(49, 51, 44, 0.14) 100%);
+    background: linear-gradient(
+      180deg,
+      rgba(255, 253, 248, 0.02) 0%,
+      rgba(255, 253, 248, 0.08) 34%,
+      rgba(255, 250, 244, 0.28) 56%,
+      rgba(255, 248, 240, 0.78) 76%,
+      rgba(255, 248, 240, 0.95) 100%
+    );
+    z-index: 1;
   }
 
-  .theme-dark .ss-landing .ss-landing__scene-card::after ,
-  .ss-landing.is-dark .ss-landing__scene-card::after  {
-    background: linear-gradient(180deg, transparent 20%, rgba(0, 0, 0, 0.3) 100%);
+  .theme-dark .ss-landing .ss-landing__scene-card::after,
+  .ss-landing.is-dark .ss-landing__scene-card::after {
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      transparent 38%,
+      rgba(18, 26, 22, 0.75) 65%,
+      rgba(18, 26, 22, 0.96) 100%
+    );
   }
 
   .ss-landing__scene-card--policy::before {
@@ -1128,35 +1390,6 @@
     gap: 1rem;
   }
 
-  .ss-landing__scene-img-wrap {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    overflow: hidden;
-  }
-
-  .ss-landing__scene-img {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: center;
-    opacity: 0.68;
-    transform: scale(1.01);
-    transition: transform 0.7s ease, opacity 0.45s ease;
-  }
-
-  .theme-dark .ss-landing .ss-landing__scene-img,
-  .ss-landing.is-dark .ss-landing__scene-img {
-    opacity: 0.5;
-    mix-blend-mode: screen;
-  }
-
-  .ss-landing__scene-card:hover .ss-landing__scene-img {
-    transform: scale(1.05);
-    opacity: 0.8;
-  }
-
   .ss-landing__scene-subtitle {
     display: block;
     margin-top: 0.3rem;
@@ -1178,7 +1411,7 @@
 
   .ss-landing__scene-body {
     max-width: 18rem;
-    color: rgba(49, 51, 44, 0.78);
+    color: rgba(39, 35, 30, 0.82);
     opacity: 0.9;
   }
 
@@ -1286,7 +1519,7 @@
   .ss-landing__decision-copy {
     display: flex;
     flex-direction: column;
-    gap: var(--ss-space-2);
+    gap: 0.5rem;
   }
 
   .ss-landing__decision-label {
@@ -1306,9 +1539,44 @@
     transform: translateX(2px);
   }
 
+  @keyframes ss-landing-subtitle-type-in {
+    0% {
+      opacity: 0;
+      transform: translateY(0.7rem);
+      filter: blur(0.7rem);
+      clip-path: inset(0 100% 0 0);
+      text-shadow: 0 0 0 rgba(212, 162, 78, 0);
+    }
+
+    35% {
+      opacity: 0.62;
+      text-shadow: 0 0 1.4rem rgba(212, 162, 78, 0.12);
+    }
+
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0);
+      clip-path: inset(0 0 0 0);
+      text-shadow: 0 0 1.2rem rgba(212, 162, 78, 0.08);
+    }
+  }
+
+  @keyframes ss-landing-subtitle-caret-loop {
+    0%,
+    49% {
+      opacity: 0;
+    }
+
+    50%,
+    100% {
+      opacity: 1;
+    }
+  }
+
   @media (max-width: 1152px) {
     .ss-landing {
-      gap: 4.5rem;
+      gap: 3.2rem;
     }
 
     .ss-landing__frame {
@@ -1316,15 +1584,10 @@
     }
 
     .ss-landing__hero-grid {
-      gap: clamp(1.6rem, 3vw, 3rem);
+      gap: clamp(1.2rem, 2.4vw, 2rem);
     }
 
     .ss-landing__preview-image {
-      min-height: 31rem;
-    }
-
-    .ss-landing__preview-stage--video,
-    .ss-landing__preview-video {
       min-height: 31rem;
     }
   }
@@ -1348,16 +1611,24 @@
   }
 
   @media (max-width: 960px) {
+    .ss-landing__hero-footer {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 1.15rem;
+      padding-top: 0;
+      border-top: none;
+    }
+
+    .ss-landing__tag-row {
+      justify-content: flex-start;
+    }
+
     .ss-landing__entry-board {
       max-width: 48rem;
     }
 
     .ss-landing__preview-image {
-      min-height: 28rem;
-    }
-
-    .ss-landing__preview-stage--video,
-    .ss-landing__preview-video {
       min-height: 28rem;
     }
 
@@ -1389,7 +1660,7 @@
 
   @media (max-width: 768px) {
     .ss-landing {
-      gap: 4rem;
+      gap: 2.8rem;
       padding-top: 0.2rem;
     }
 
@@ -1398,16 +1669,29 @@
     }
 
     .ss-landing__hero-copy {
-      gap: 1.55rem;
-      padding-block: 0.75rem;
+      min-height: auto;
+      padding: 1rem;
+      border-radius: 24px;
+    }
+
+    .ss-landing__hero-stage {
+      padding: 1.5rem;
+      border-radius: 22px;
+      min-height: 27rem;
+    }
+
+    .ss-landing__hero-body .ss-landing__subtitle {
+      font-size: clamp(1.28rem, 4.1vw, 1.52rem);
+      line-height: 1.54;
+    }
+
+    .ss-landing__hero-body .ss-landing__subtitle--dynamic {
+      gap: 0.32rem;
+      padding-right: 0;
     }
 
     .ss-landing__title {
-      font-size: clamp(2.9rem, 9vw, 4.5rem);
-    }
-
-    .ss-landing__title-accent {
-      font-size: clamp(1.2rem, 4.2vw, 1.9rem);
+      font-size: clamp(2.75rem, 8.4vw, 3.35rem);
     }
 
     .ss-landing__preview-head {
@@ -1427,7 +1711,7 @@
 
   @media (max-width: 614px) {
     .ss-landing {
-      gap: 3.25rem;
+      gap: 2.4rem;
       padding-bottom: 4rem;
     }
 
@@ -1499,12 +1783,7 @@
 
   @media (max-width: 448px) {
     .ss-landing__title {
-      font-size: clamp(2.5rem, 13vw, 3.6rem);
-    }
-
-    .ss-landing__title-accent {
-      margin-top: 0.75rem;
-      font-size: clamp(1.08rem, 5.4vw, 1.5rem);
+      font-size: clamp(2.35rem, 11vw, 2.85rem);
     }
 
     .ss-landing__subtitle,
@@ -1551,5 +1830,48 @@
     .ss-reveal {
       opacity: 1;
     }
+
+    .ss-landing__subtitle-segment {
+      opacity: 1;
+      transform: none;
+      filter: none;
+      clip-path: inset(0 0 0 0);
+      animation: none;
+    }
+
+    .ss-landing__subtitle-segment::after {
+      display: none;
+    }
+  }
+
+  /* Scene card image overlay */
+  .ss-landing__scene-img-wrap {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .ss-landing__scene-img {
+    width: 100%;
+    height: 64%;
+    object-fit: cover;
+    object-position: center top;
+    opacity: 0.88;
+    filter: saturate(1.08) contrast(1.08) brightness(0.98);
+    transition: transform 0.7s ease, opacity 0.5s ease, filter 0.5s ease;
+  }
+
+  .theme-dark .ss-landing .ss-landing__scene-img,
+  .ss-landing.is-dark .ss-landing__scene-img {
+    opacity: 0.62;
+    filter: saturate(1.02) contrast(1.04) brightness(0.88);
+  }
+
+  .ss-landing__scene-card:hover .ss-landing__scene-img {
+    transform: scale(1.08);
+    opacity: 0.96;
+    filter: saturate(1.12) contrast(1.1) brightness(1);
   }
 }

--- a/frontend/styles/system/primitives.css
+++ b/frontend/styles/system/primitives.css
@@ -212,7 +212,9 @@
   }
 
   .ss-button,
-  .button {
+  .button,
+  .ss-button-danger,
+  .button-danger {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -236,7 +238,9 @@
   }
 
   .ss-button:hover,
-  .button:hover {
+  .button:hover,
+  .ss-button-danger:hover,
+  .button-danger:hover {
     transform: translateY(-1px);
     box-shadow:
       var(--ss-glow-primary),
@@ -244,7 +248,9 @@
   }
 
   .ss-button:disabled,
-  .button:disabled {
+  .button:disabled,
+  .ss-button-danger:disabled,
+  .button-danger:disabled {
     opacity: 0.56;
     cursor: not-allowed;
     transform: none;

--- a/src/socialsim4/backend/api/routes/llm.py
+++ b/src/socialsim4/backend/api/routes/llm.py
@@ -14,6 +14,7 @@ from ...core.database import get_session
 from ...dependencies import extract_bearer_token, resolve_current_user
 from ...models.user import ProviderConfig
 from ...services.default_providers import get_default_ollama_base_url
+from ...services.provider_dialect import normalize_provider_dialect
 
 # 👇 关键：这里需要上升 3 层到 socialsim4，然后再进入 core
 from ....core.llm import create_llm_client, generate_agents_with_archetypes
@@ -100,7 +101,7 @@ async def _select_provider(
     if provider is None:
             raise RuntimeError("LLM provider not configured")
 
-    dialect = (provider.provider or "").lower()
+    dialect = normalize_provider_dialect(provider.provider)
     if dialect not in {"openai", "gemini", "mock", "ollama"}:
         raise RuntimeError("Invalid LLM provider dialect")
     if dialect in {"openai", "gemini"} and not provider.api_key:
@@ -127,7 +128,7 @@ async def generate_agents(
         provider = await _select_provider(
             session, current_user.id, data.provider_id
         )
-        dialect = (provider.provider or "").lower()
+        dialect = normalize_provider_dialect(provider.provider)
 
         cfg = LLMConfig(
             dialect=dialect,
@@ -295,7 +296,7 @@ async def refine_report(request: Request, data: RefineReportRequest) -> dict:
         current_user = await resolve_current_user(session, token)
         provider = await _select_provider(session, current_user.id, data.provider_id)
         cfg = LLMConfig(
-            dialect=(provider.provider or "").lower(),
+            dialect=normalize_provider_dialect(provider.provider),
             api_key=provider.api_key or "",
             model=provider.model,
             base_url=provider.base_url,
@@ -342,7 +343,7 @@ async def generate_agents_demographics(
                 session, current_user.id, data.provider_id
             )
 
-            dialect = (provider.provider or "").lower()
+            dialect = normalize_provider_dialect(provider.provider)
             cfg = LLMConfig(
                 dialect=dialect,
                 api_key=provider.api_key or "",

--- a/src/socialsim4/backend/api/routes/providers.py
+++ b/src/socialsim4/backend/api/routes/providers.py
@@ -30,6 +30,7 @@ from ...models.user import ProviderConfig
 from ...schemas.common import Message
 from ...schemas.provider import ProviderBase, ProviderCreate, ProviderUpdate
 from ...services.default_providers import ensure_default_ollama_providers
+from ...services.provider_dialect import normalize_provider_dialect
 
 
 def _normalize_dialect(raw: str, base_url: str | None) -> tuple[str, str | None]:
@@ -46,7 +47,7 @@ def _normalize_dialect(raw: str, base_url: str | None) -> tuple[str, str | None]
     Returns:
         Tuple of (normalized_dialect, normalized_base_url)
     """
-    val = (raw or "").lower().strip()
+    val = normalize_provider_dialect(raw)
     if val == "ollama":
         # Strip /v1 suffix if present (native Ollama API doesn't use it)
         if base_url and "/v1" in base_url:
@@ -62,10 +63,14 @@ def _normalize_dialect(raw: str, base_url: str | None) -> tuple[str, str | None]
 
 
 def _serialize_provider(provider: ProviderConfig) -> ProviderBase:
+    serialized_provider = provider.provider
+    if normalize_provider_dialect(provider.provider) == "openai":
+        serialized_provider = "openai-compatible"
+
     return ProviderBase(
         id=provider.id,
         name=provider.name,
-        provider=provider.provider,
+        provider=serialized_provider,
         model=provider.model,
         base_url=provider.base_url,
         has_api_key=bool(provider.api_key),
@@ -112,7 +117,7 @@ async def create_provider(request: Request, data: ProviderCreate) -> ProviderBas
         provider = ProviderConfig(
             user_id=current_user.id,
             name=data.name,
-            provider=data.provider,
+            provider=normalize_provider_dialect(data.provider),
             model=data.model,
             base_url=data.base_url,
             api_key=data.api_key,
@@ -137,7 +142,7 @@ async def update_provider(
         if data.name is not None:
             provider.name = data.name
         if data.provider is not None:
-            provider.provider = data.provider
+            provider.provider = normalize_provider_dialect(data.provider)
         if data.model is not None:
             provider.model = data.model
         if data.base_url is not None:

--- a/src/socialsim4/backend/api/routes/simulations/crud.py
+++ b/src/socialsim4/backend/api/routes/simulations/crud.py
@@ -36,6 +36,7 @@ from socialsim4.backend.schemas.simulation import (
 )
 from socialsim4.backend.schemas.simtree import UpdateAgentLLMConfigRequest
 from socialsim4.backend.services.simulations import generate_simulation_id, generate_simulation_name
+from socialsim4.backend.services.provider_dialect import normalize_provider_dialect
 from socialsim4.backend.services.simtree_runtime import SIM_TREE_REGISTRY
 
 from .helpers import (
@@ -190,7 +191,7 @@ async def create_simulation(
         if provider is None:
             raise RuntimeError("LLM provider not configured")
 
-        dialect = (provider.provider or "").lower()
+        dialect = normalize_provider_dialect(provider.provider)
         if dialect not in {"openai", "gemini", "mock", "ollama"}:
             raise RuntimeError("Invalid LLM provider dialect")
         if dialect in {"openai", "gemini"} and not provider.api_key:

--- a/src/socialsim4/backend/api/routes/simulations/helpers.py
+++ b/src/socialsim4/backend/api/routes/simulations/helpers.py
@@ -32,6 +32,7 @@ from socialsim4.backend.dependencies import settings
 from socialsim4.backend.models.simulation import Simulation
 from socialsim4.backend.models.user import ProviderConfig, SearchProviderConfig, User
 from socialsim4.backend.services.default_providers import get_default_ollama_base_url
+from socialsim4.backend.services.provider_dialect import normalize_provider_dialect
 from socialsim4.backend.services.simtree_runtime import SIM_TREE_REGISTRY, SimTreeRecord
 
 
@@ -107,7 +108,7 @@ async def get_tree_record(
             status_code=400,
             detail="LLM provider not configured"
         )
-    dialect = (provider.provider or "").lower()
+    dialect = normalize_provider_dialect(provider.provider)
     base_url = provider.base_url or (get_default_ollama_base_url() if dialect == "ollama" else None)
 
     # Heuristic: openai + localhost base_url without /v1 => append /v1 for OpenAI-compatible servers like Ollama
@@ -159,7 +160,7 @@ async def get_tree_record(
     # Build per-provider client map for LLM distribution across agents
     provider_clients: dict[int, object] = {}
     for p in items:
-        p_dialect = (p.provider or "").lower()
+        p_dialect = normalize_provider_dialect(p.provider)
         if p_dialect not in {"openai", "gemini", "mock", "ollama"}:
             continue
         if p_dialect in {"openai", "gemini"} and not p.api_key:

--- a/src/socialsim4/backend/services/experiment_tasks.py
+++ b/src/socialsim4/backend/services/experiment_tasks.py
@@ -15,6 +15,7 @@ from socialsim4.core.llm import create_llm_client
 from socialsim4.core.llm_config import LLMConfig, guess_supports_vision
 from socialsim4.backend.models.user import ProviderConfig, SearchProviderConfig
 from socialsim4.backend.services.default_providers import get_default_ollama_base_url
+from socialsim4.backend.services.provider_dialect import normalize_provider_dialect
 from socialsim4.core.tools.web.search import create_search_client
 from socialsim4.core.search_config import SearchConfig
 
@@ -57,7 +58,7 @@ def run_experiment_task(self, simulation_id: str, exp_id: str, run_id: int, turn
             active_provider = None  # Track active provider for quota management
 
             for provider in items:
-                dialect = (provider.provider or "").lower()
+                dialect = normalize_provider_dialect(provider.provider)
                 cfg = LLMConfig(
                     dialect=dialect,
                     api_key=provider.api_key or "",

--- a/src/socialsim4/backend/services/provider_dialect.py
+++ b/src/socialsim4/backend/services/provider_dialect.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def normalize_provider_dialect(raw: str | None) -> str:
+    value = (raw or "").strip().lower().replace("_", "-")
+    if value == "openai-compatible":
+        return "openai"
+    return value


### PR DESCRIPTION
更新日志

本次更新主要完成了两部分：一是将 `rescue` 分支中的“设置 -> LLM 配置”界面迁移并适配到当前分支，二是修正“设置 -> 安全 -> 会话控制”中的“退出所有会话”按钮样式，使其与系统内其他按钮保持一致。

1. 设置页 LLM 配置界面迁移
- 将设置页中的 `LLM 配置` 入口恢复为独立的 Provider 管理界面，不再使用当前分支中那套简化的内联表单，而是接入完整的管理页组件，包含 provider 列表、创建/编辑抽屉、连接测试、设为默认、删除等操作。 代码位置：frontend/pages/SettingsPage.tsx
- 复用现有的 Provider 管理组件体系，保持前端调用的仍然是原有 providers API，而不是重写一套新的接口逻辑。这样做的目标是只增强界面组织方式，不改变原本的配置流程。 代码位置：frontend/components/provider-management/ProviderManagementPage.tsx
- 为兼容新界面使用的 `openai-compatible` provider 类型，后端新增了统一的 provider 方言归一化逻辑，在运行时内部将其映射为现有 LLM core 可识别的 `openai`，避免测试连接、生成 agent、创建仿真时出现“不认识 dialect”的问题。 代码位置：src/socialsim4/backend/services/provider_dialect.py
- 在 providers 路由中接入归一化，但同时保留对前端的返回语义兼容：接口对外仍返回 `openai-compatible`，避免破坏前端设置页和管理抽屉的原有类型判断。这一条是为了确保本次改动属于“锦上添花”，而不是改变既有 API 合同。 代码位置：src/socialsim4/backend/api/routes/providers.py
- 在 LLM 调用链和仿真创建链路中同步接入 provider 方言归一化，确保以下场景仍能读取并使用当前激活的 provider：
  - LLM 测试连接
  - 生成 agents
  - 人口学生成
  - 创建 simulation
  - simulation runtime 读取 provider client
  - experiment task 内部构建 provider client 代码位置： src/socialsim4/backend/api/routes/llm.py src/socialsim4/backend/api/routes/simulations/crud.py src/socialsim4/backend/api/routes/simulations/helpers.py src/socialsim4/backend/services/experiment_tasks.py

2. 设置页“退出所有会话”按钮样式修正
- 修正了“设置 -> 安全 -> 会话控制”中“退出所有会话”按钮的基础样式。此前该按钮虽然使用了 `ss-button-danger`，但这套危险按钮样式只定义了颜色，没有继承普通按钮的圆角矩形布局，因此视觉上会变成长条且不一致。
- 现在将 `ss-button-danger` 纳入与普通按钮同一套基础按钮几何样式中，使其拥有和其他按钮一致的：
  - 圆角矩形外观
  - 内边距
  - inline-flex 布局
  - hover 动效
  - disabled 状态
- 这次修改只调整按钮的基础盒模型，不改变危险按钮本身的红色语义，也不影响归档页等已经额外定义过局部按钮样式的区域。 代码位置：frontend/styles/system/primitives.css

结果总结
- `设置 -> LLM 配置` 现在恢复为完整的管理页形态，前端体验与 rescue 分支一致。
- 后端对 `openai-compatible` 做了兼容处理，但没有破坏原有 providers API 的前端返回语义。
- `设置 -> 安全` 中的“退出所有会话”按钮现在与系统其他按钮在视觉上保持一致，为标准圆角矩形按钮。